### PR TITLE
feat: 프로모션 등록 기능 개발

### DIFF
--- a/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
+++ b/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
@@ -1,0 +1,40 @@
+package yjh.devtoon.promotion.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
+import yjh.devtoon.promotion.domain.PromotionEntity;
+import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
+import yjh.devtoon.promotion.infrastructure.PromotionAttributeRepository;
+import yjh.devtoon.promotion.infrastructure.PromotionRepository;
+
+@RequiredArgsConstructor
+@Service
+public class PromotionService {
+
+    private final PromotionRepository promotionRepository;
+    private final PromotionAttributeRepository promotionAttributeRepository;
+
+    @Transactional
+    public void register(final PromotionCreateRequest request) {
+
+        PromotionEntity promotion = PromotionEntity.create(
+                request.getDescription(),
+                request.getStartDate(),
+                request.getEndDate()
+        );
+
+        PromotionEntity savedPromotionEntity = promotionRepository.save(promotion);
+
+        PromotionAttributeEntity attribute = PromotionAttributeEntity.create(
+                savedPromotionEntity,
+                request.getAttributeName(),
+                request.getAttributeValue()
+        );
+
+        promotionAttributeRepository.save(attribute);
+
+    }
+
+}

--- a/src/main/java/yjh/devtoon/promotion/domain/PromotionAttributeEntity.java
+++ b/src/main/java/yjh/devtoon/promotion/domain/PromotionAttributeEntity.java
@@ -1,0 +1,63 @@
+package yjh.devtoon.promotion.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yjh.devtoon.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "promotion_attribute")
+@Entity
+public class PromotionAttributeEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "promotion_attribute_no", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "promotion_no")
+    private PromotionEntity promotionEntity;
+
+    @Column(name = "attribute_name", nullable = false)
+    private String attributeName;
+
+    @Column(name = "attribute_value", nullable = false)
+    private String attributeValue;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    @Builder
+    public PromotionAttributeEntity(
+            final Long id,
+            final PromotionEntity promotionEntity,
+            final String attributeName,
+            final String attributeValue,
+            final LocalDateTime deletedAt
+    ) {
+        this.id = id;
+        this.promotionEntity = promotionEntity;
+        this.attributeName = attributeName;
+        this.attributeValue = attributeValue;
+        this.deletedAt = deletedAt;
+    }
+
+    public static PromotionAttributeEntity create(
+            final PromotionEntity promotionEntity,
+            final String attributeName,
+            final String attributeValue
+    ) {
+        return PromotionAttributeEntity.builder()
+                .promotionEntity(promotionEntity)
+                .attributeName(attributeName)
+                .attributeValue(attributeValue)
+                .build();
+    }
+
+}

--- a/src/main/java/yjh/devtoon/promotion/domain/PromotionEntity.java
+++ b/src/main/java/yjh/devtoon/promotion/domain/PromotionEntity.java
@@ -1,0 +1,62 @@
+package yjh.devtoon.promotion.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yjh.devtoon.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "promotion")
+@Entity
+public class PromotionEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "promotion_no", nullable = false)
+    private Long id;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date")
+    private LocalDateTime endDate;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    @Builder
+    public PromotionEntity(
+            final Long id,
+            final String description,
+            final LocalDateTime startDate,
+            final LocalDateTime endDate,
+            final LocalDateTime deletedAt
+    ) {
+        this.id = id;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.deletedAt = deletedAt;
+    }
+
+    public static PromotionEntity create(
+            final String description,
+            final LocalDateTime startDate,
+            final LocalDateTime endDate
+    ) {
+        return PromotionEntity.builder()
+                .description(description)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+    }
+
+}

--- a/src/main/java/yjh/devtoon/promotion/dto/request/PromotionCreateRequest.java
+++ b/src/main/java/yjh/devtoon/promotion/dto/request/PromotionCreateRequest.java
@@ -1,0 +1,43 @@
+package yjh.devtoon.promotion.dto.request;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PromotionCreateRequest {
+
+    @NotBlank(message = "description을 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
+    private final String description;
+
+    @NotNull(message = "시작 날짜는 필수입니다.")
+    @FutureOrPresent(message = "시작 날짜는 현재 시간이나 그 이후여야 합니다.")
+    private final LocalDateTime startDate;
+
+    @FutureOrPresent(message = "종료 날짜는 현재 시간이나 그 이후여야 합니다.")
+    private final LocalDateTime endDate;
+
+    @NotBlank(message = "attribute_name을 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
+    private final String attributeName;
+
+    @NotBlank(message = "attribute_value을 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
+    private final String attributeValue;
+
+    public PromotionCreateRequest(
+            String description,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            String attributeName,
+            String attributeValue
+    ) {
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.attributeName = attributeName;
+        this.attributeValue = attributeValue;
+    }
+
+}

--- a/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionAttributeRepository.java
+++ b/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionAttributeRepository.java
@@ -1,0 +1,7 @@
+package yjh.devtoon.promotion.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
+
+public interface PromotionAttributeRepository extends JpaRepository<PromotionAttributeEntity, Long> {
+}

--- a/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionRepository.java
+++ b/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionRepository.java
@@ -1,0 +1,7 @@
+package yjh.devtoon.promotion.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yjh.devtoon.promotion.domain.PromotionEntity;
+
+public interface PromotionRepository extends JpaRepository<PromotionEntity, Long> {
+}

--- a/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
+++ b/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
@@ -1,0 +1,32 @@
+package yjh.devtoon.promotion.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yjh.devtoon.common.response.Response;
+import yjh.devtoon.promotion.application.PromotionService;
+import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
+
+@RequestMapping("/v1/promotions")
+@RequiredArgsConstructor
+@RestController
+public class PromotionController {
+
+    private final PromotionService promotionService;
+
+    /**
+     * 프로모션 등록
+     */
+    @PostMapping
+    public ResponseEntity<Response> register(
+            @RequestBody @Valid final PromotionCreateRequest request
+    ) {
+        promotionService.register(request);
+        return ResponseEntity.ok(Response.success(null));
+    }
+
+}

--- a/src/test/java/yjh/devtoon/promotion/application/PromotionServiceTest.java
+++ b/src/test/java/yjh/devtoon/promotion/application/PromotionServiceTest.java
@@ -1,0 +1,55 @@
+package yjh.devtoon.promotion.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
+import yjh.devtoon.promotion.infrastructure.PromotionAttributeRepository;
+import yjh.devtoon.promotion.infrastructure.PromotionRepository;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@ExtendWith(MockitoExtension.class)
+class PromotionServiceTest {
+
+    @InjectMocks
+    private PromotionService promotionService;
+
+    @Mock
+    private PromotionRepository promotionRepository;
+
+    @Mock
+    private PromotionAttributeRepository promotionAttributeRepository;
+
+    @Nested
+    @DisplayName("프로모션 등록 테스트")
+    class RegisterPromotionTests {
+
+        @Test
+        @DisplayName("프로모션 등록 요청 시 성공적으로 등록")
+        void registerPromotion_successfully() {
+            // given
+            String description = "12월 크리스마스 프로모션입니다.";
+            LocalDateTime startDate = LocalDateTime.parse("2024-05-10T00:00:00");
+            LocalDateTime endDate = LocalDateTime.parse("2024-05-13T11:59:59");
+            String attributeName = "target-month";
+            String attributeValue = "12";
+
+            PromotionCreateRequest request = new PromotionCreateRequest(
+                    description, startDate, endDate, attributeName, attributeValue
+            );
+
+            // when, then
+            assertThatCode(() -> promotionService.register(request))
+                    .doesNotThrowAnyException();
+        }
+
+    }
+
+}

--- a/src/test/java/yjh/devtoon/promotion/domain/PromotionAttributeEntityTest.java
+++ b/src/test/java/yjh/devtoon/promotion/domain/PromotionAttributeEntityTest.java
@@ -1,0 +1,35 @@
+package yjh.devtoon.promotion.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("도메인 단위 테스트 [PromotionAttribute]")
+class PromotionAttributeEntityTest {
+
+    @Test
+    @DisplayName("[create() 테스트] : 프로모션 속성 엔티티 생성 테스트")
+    public void createPromotionAttributeEntityTest() {
+        // given
+        PromotionEntity promotionEntity = new PromotionEntity();
+        String attributeName = "target-month";
+        String attributeValue = "JUL";
+
+
+        // when
+        PromotionAttributeEntity attribute = PromotionAttributeEntity.create(
+                promotionEntity, attributeName, attributeValue
+        );
+
+        // then
+        assertAll("attribute",
+                () -> assertEquals(promotionEntity, attribute.getPromotionEntity()),
+                () -> assertEquals(attributeName, attribute.getAttributeName()),
+                () -> assertEquals(attributeValue, attribute.getAttributeValue()),
+                () -> assertNull(attribute.getDeletedAt())
+        );
+
+    }
+
+}

--- a/src/test/java/yjh/devtoon/promotion/domain/PromotionEntityTest.java
+++ b/src/test/java/yjh/devtoon/promotion/domain/PromotionEntityTest.java
@@ -1,0 +1,36 @@
+package yjh.devtoon.promotion.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("도메인 단위 테스트 [Promotion]")
+class PromotionEntityTest {
+
+    @Test
+    @DisplayName("[create() 테스트] : 프로모션 엔티티 생성 테스트")
+    public void createPromotionEntityTest() {
+        // given
+        String description = "여름 프로모션입니다.";
+        LocalDateTime startDate = LocalDateTime.of(2024, 6, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2024, 6, 30, 23, 59);
+
+        // when
+        PromotionEntity promotion = PromotionEntity.create(
+                description, startDate, endDate
+        );
+
+        // then
+        assertAll("promotion",
+                () -> assertEquals(description, promotion.getDescription()),
+                () -> assertEquals(startDate, promotion.getStartDate()),
+                () -> assertEquals(endDate, promotion.getEndDate()),
+                () -> assertNull(promotion.getDeletedAt())
+        );
+
+    }
+
+}


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 프로모션 등록 기능 
- [x] 도메인 단위테스트 
- [x] 서비스 단위테스트 

## 💡️ 이슈
- 프로모션 등록 API 테스트 중 데이터베이스 테이블 컬럼명과 엔티티 필드명이 일치하지 않아 에러가 발생했습니다. 이를 방지하기 위해 습관적으로 @Column(name = “ ”) 을 명시하도록 하겠습니다. 단, 외래키의 경우 @Column이 아닌 → @JoinColumn 사용

## 📢 논의하고 싶은 내용
- 기본 CRUD 구현 시 공통 메서드 명을 사용하는 것이 어떨까요? 타인이 작성한 코드의 이해도를 높이는 데 도움이 될 것 같습니다! 😀