### PR TITLE
fix: 프로모션 조회 에러 수정

### DIFF
--- a/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
+++ b/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
@@ -33,13 +33,11 @@ public class PromotionService {
      */
     @Transactional
     public void register(final PromotionCreateRequest request) {
-
         PromotionEntity promotion = PromotionEntity.create(
                 request.getDescription(),
                 request.getStartDate(),
                 request.getEndDate()
         );
-
         PromotionEntity savedPromotion = promotionRepository.save(promotion);
 
         PromotionAttributeEntity attribute = PromotionAttributeEntity.create(
@@ -47,9 +45,7 @@ public class PromotionService {
                 request.getAttributeName(),
                 request.getAttributeValue()
         );
-
         promotionAttributeRepository.save(attribute);
-
     }
 
     /**
@@ -57,7 +53,6 @@ public class PromotionService {
      */
     @Transactional
     public PromotionSoftDeleteResponse softDelete(final Long id) {
-
         PromotionEntity promotion = promotionRepository.findById(id)
                 .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND,
                         ErrorMessage.getResourceNotFound("Promotion", id)));
@@ -66,7 +61,6 @@ public class PromotionService {
         PromotionEntity softDeletedPromotion = promotionRepository.save(promotion);
 
         return PromotionSoftDeleteResponse.from(softDeletedPromotion);
-
     }
 
     /**
@@ -75,7 +69,7 @@ public class PromotionService {
      */
     @Transactional(readOnly = true)
     public Page<RetrieveActivePromotionsResponse> retrieveActivePromotions(
-            Pageable pageable
+            final Pageable pageable
     ) {
         // 활성화된 프로모션 목록 조회
         Page<PromotionEntity> activePromotions = validateActivePromotionExists(pageable);
@@ -88,7 +82,7 @@ public class PromotionService {
         });
     }
 
-    private Page<PromotionEntity> validateActivePromotionExists(Pageable pageable) {
+    private Page<PromotionEntity> validateActivePromotionExists(final Pageable pageable) {
         LocalDateTime currentTime = LocalDateTime.now();
         Page<PromotionEntity> promotions = promotionRepository.findActivePromotions(
                 currentTime, pageable
@@ -100,7 +94,9 @@ public class PromotionService {
         return promotions;
     }
 
-    private PromotionAttributeEntity validatePromotionAttributeExists(PromotionEntity promotionEntity) {
+    private PromotionAttributeEntity validatePromotionAttributeExists(
+            final PromotionEntity promotionEntity
+    ) {
         PromotionAttributeEntity promotionAttribute =
                 promotionAttributeRepository.findByPromotionEntityId(promotionEntity.getId())
                         .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND,

--- a/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
+++ b/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
@@ -3,6 +3,7 @@ package yjh.devtoon.promotion.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,13 +13,12 @@ import yjh.devtoon.promotion.constant.ErrorMessage;
 import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
 import yjh.devtoon.promotion.domain.PromotionEntity;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
-import yjh.devtoon.promotion.dto.request.RetrieveActivePromotionsRequest;
 import yjh.devtoon.promotion.dto.response.PromotionSoftDeleteResponse;
 import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionsResponse;
 import yjh.devtoon.promotion.infrastructure.PromotionAttributeRepository;
 import yjh.devtoon.promotion.infrastructure.PromotionRepository;
 import java.time.LocalDateTime;
-import java.util.Optional;
+import java.util.Collections;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -59,7 +59,8 @@ public class PromotionService {
     public PromotionSoftDeleteResponse softDelete(final Long id) {
 
         PromotionEntity promotion = promotionRepository.findById(id)
-                .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND, ErrorMessage.getResourceNotFound("Promotion", id)));
+                .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND,
+                        ErrorMessage.getResourceNotFound("Promotion", id)));
 
         promotion.recordDeletion(LocalDateTime.now());
         PromotionEntity softDeletedPromotion = promotionRepository.save(promotion);
@@ -69,42 +70,46 @@ public class PromotionService {
     }
 
     /**
-     * 현재 적용 가능한 프로모션 전체 조회
+     * 현재 활성화된 프로모션 전체 조회
+     * : 현재 활성화된 프로모션이 없는 경우 빈 페이지를 반환합니다.
      */
     @Transactional(readOnly = true)
     public Page<RetrieveActivePromotionsResponse> retrieveActivePromotions(
-            final RetrieveActivePromotionsRequest request,
             Pageable pageable
     ) {
-        // 유효한 프로모션의 존재 여부를 확인
-        if (!promotionRepository.existsByDateRange(request.getStartDate(), request.getEndDate())) {
-            throw new DevtoonException(
-                    ErrorCode.NOT_FOUND,
-                    ErrorMessage.getResourceNotFound(
-                            "Promotion",
-                            String.format("from %s to %s", request.getStartDate(), request.getEndDate())
-                    )
-            );
-        }
+        // 활성화된 프로모션 목록 조회
+        Page<PromotionEntity> activePromotions = validateActivePromotionExists(pageable);
 
-        // 유효한 프로모션 조회
-        Page<PromotionEntity> activePromotions = promotionRepository.findActivePromotions(request.getStartDate(), request.getEndDate(), pageable);
-        log.info("조회된 유효 프로모션 수: {}", activePromotions.getNumberOfElements());
-
-        // 프로모션 엔티티를 응답 DTO로 변환
+        // 각 프로모션 엔티티를 프로모션 속성과 함께 응답 객체로 변환
         return activePromotions.map(promotionEntity -> {
-            Optional<PromotionAttributeEntity> promotionAttributeEntity = promotionAttributeRepository.findByPromotionEntityId(promotionEntity.getId());
-
-            PromotionAttributeEntity attributeEntity = promotionAttributeEntity.orElseThrow(() ->
-                    new DevtoonException(
-                            ErrorCode.NOT_FOUND,
-                            String.format("Attribute for promotion ID %s not found.", promotionEntity.getId())
-                    )
-            );
-            log.info("성공적으로 조회된 attribute: {} for promotion: {}", attributeEntity, promotionEntity);
-
-            return RetrieveActivePromotionsResponse.from(promotionEntity, attributeEntity);
+            PromotionAttributeEntity promotionAttribute =
+                    validatePromotionAttributeExists(promotionEntity);
+            return RetrieveActivePromotionsResponse.from(promotionEntity, promotionAttribute);
         });
+    }
+
+    private Page<PromotionEntity> validateActivePromotionExists(Pageable pageable) {
+        LocalDateTime currentTime = LocalDateTime.now();
+        Page<PromotionEntity> promotions = promotionRepository.findActivePromotions(
+                currentTime, pageable
+        );
+
+        if (promotions.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+        return promotions;
+    }
+
+    private PromotionAttributeEntity validatePromotionAttributeExists(PromotionEntity promotionEntity) {
+        PromotionAttributeEntity promotionAttribute =
+                promotionAttributeRepository.findByPromotionEntityId(promotionEntity.getId())
+                        .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND,
+                                ErrorMessage.getResourceNotFound(
+                                        "PromotionEntity",
+                                        promotionEntity.getId()
+                                ))
+                        );
+        return promotionAttribute;
     }
 
 }

--- a/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionRepository.java
+++ b/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionRepository.java
@@ -12,27 +12,15 @@ import java.util.List;
 public interface PromotionRepository extends JpaRepository<PromotionEntity, Long> {
 
     /**
-     * 요청된 기간 내 유효한 프로모션이 데이터베이스에 존재하는지 확인합니다.
-     */
-    @Query("SELECT COUNT(p) > 0 FROM PromotionEntity p WHERE p.startDate <= :endDate AND p.endDate >= :startDate")
-    boolean existsByDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
-
-    /**
-     * 요청된 기간 내 모든 유효한 프로모션을 페이지화하여 반환합니다.
-     */
-    @Query("SELECT p FROM PromotionEntity p WHERE p.startDate <= :endDate AND p.endDate >= :startDate")
-    Page<PromotionEntity> findActivePromotions(
-            @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate,
-            Pageable pageable
-    );
-
-    /**
-     * 현재 적용 가능한 모든 유효한 프로모션을 리스트로 반환합니다.
-     * : 현재 시간이 프로모션 적용시간 시작과 끝 사이여야한다.
+     * 현재 활성화된 모든 프로모션을 리스트로 반환합니다.
      */
     @Query("SELECT p FROM PromotionEntity p WHERE p.startDate <= :now AND p.endDate >= :now")
     List<PromotionEntity> activePromotions(@Param("now") LocalDateTime now);
 
+    /**
+     * 현재 활성화된 모든 프로모션을 페이지로 반환합니다.
+     */
+    @Query("SELECT p FROM PromotionEntity p WHERE p.startDate <= :now AND p.endDate >= :now")
+    Page<PromotionEntity> findActivePromotions(@Param("now") LocalDateTime now, Pageable pageable);
 
 }

--- a/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
+++ b/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 import yjh.devtoon.common.response.ApiReponse;
 import yjh.devtoon.promotion.application.PromotionService;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
-import yjh.devtoon.promotion.dto.request.RetrieveActivePromotionsRequest;
 import yjh.devtoon.promotion.dto.response.PromotionSoftDeleteResponse;
 import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionsResponse;
 
@@ -51,20 +50,15 @@ public class PromotionController {
     }
 
     /**
-     * 현재 적용 가능한 프로모션 전체 조회
+     * 현재 활성화된 프로모션 전체 조회
+     * : 현재 활성화된 프로모션이 없는 경우 빈 페이지를 반환합니다.
      */
     @GetMapping("/now")
     public ResponseEntity<ApiReponse<Page<RetrieveActivePromotionsResponse>>> retrieveActivePromotions(
-            @RequestBody final RetrieveActivePromotionsRequest request,
             Pageable pageable
     ) {
-        Page<RetrieveActivePromotionsResponse> activePromotions = promotionService.retrieveActivePromotions(request, pageable);
-        if (activePromotions.hasContent()) {
-            activePromotions.getContent().forEach(promotion -> log.info("프로모션 상세 조회: {}", promotion));
-        } else {
-            log.info("조회된 프로모션 없음.");
-        }
-
+        Page<RetrieveActivePromotionsResponse> activePromotions =
+                promotionService.retrieveActivePromotions(pageable);
         return ResponseEntity.ok(ApiReponse.success(activePromotions));
     }
 

--- a/src/test/java/yjh/devtoon/promotion/integration/PromotionIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/promotion/integration/PromotionIntegrationTest.java
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
 import yjh.devtoon.promotion.domain.PromotionEntity;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
-import yjh.devtoon.promotion.dto.request.RetrieveActivePromotionsRequest;
 import yjh.devtoon.promotion.infrastructure.PromotionAttributeRepository;
 import yjh.devtoon.promotion.infrastructure.PromotionRepository;
 import java.time.LocalDateTime;
@@ -120,22 +119,34 @@ public class PromotionIntegrationTest {
         private static Stream<Arguments> givenInvalidField_whenRegisterPromotion_thenThrowException() {
             return Stream.of(
                     // description 유효성 검사
-                    Arguments.of(null, LocalDateTime.now(), LocalDateTime.now().plusDays(1), "attributeName", "attributeValue"),
-                    Arguments.of("", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "attributeName", "attributeValue"),
-                    Arguments.of(" ", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "attributeName", "attributeValue"),
+                    Arguments.of(null, LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+                            "attributeName", "attributeValue"),
+                    Arguments.of("", LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+                            "attributeName", "attributeValue"),
+                    Arguments.of(" ", LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+                            "attributeName", "attributeValue"),
                     // startDate 유효성 검사
-                    Arguments.of("description", null, LocalDateTime.now().plusDays(1), "attributeName", "attributeValue"),
-                    Arguments.of("description", LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1), "attributeName", "attributeValue"),
+                    Arguments.of("description", null, LocalDateTime.now().plusDays(1),
+                            "attributeName", "attributeValue"),
+                    Arguments.of("description", LocalDateTime.now().minusDays(1),
+                            LocalDateTime.now().plusDays(1), "attributeName", "attributeValue"),
                     // endDate 유효성 검사
-                    Arguments.of("description", LocalDateTime.now(), LocalDateTime.now().minusDays(1), "attributeName", "attributeValue"),
+                    Arguments.of("description", LocalDateTime.now(),
+                            LocalDateTime.now().minusDays(1), "attributeName", "attributeValue"),
                     // attributeName 유효성 검사
-                    Arguments.of("description", LocalDateTime.now(), LocalDateTime.now().plusDays(1), null, "attributeValue"),
-                    Arguments.of("description", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "", "attributeValue"),
-                    Arguments.of("description", LocalDateTime.now(), LocalDateTime.now().plusDays(1), " ", "attributeValue"),
+                    Arguments.of("description", LocalDateTime.now(),
+                            LocalDateTime.now().plusDays(1), null, "attributeValue"),
+                    Arguments.of("description", LocalDateTime.now(),
+                            LocalDateTime.now().plusDays(1), "", "attributeValue"),
+                    Arguments.of("description", LocalDateTime.now(),
+                            LocalDateTime.now().plusDays(1), " ", "attributeValue"),
                     // attributeValue 유효성 검사
-                    Arguments.of("description", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "attributeName", null),
-                    Arguments.of("description", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "attributeName", ""),
-                    Arguments.of("description", LocalDateTime.now(), LocalDateTime.now().plusDays(1), "attributeName", " ")
+                    Arguments.of("description", LocalDateTime.now(),
+                            LocalDateTime.now().plusDays(1), "attributeName", null),
+                    Arguments.of("description", LocalDateTime.now(),
+                            LocalDateTime.now().plusDays(1), "attributeName", ""),
+                    Arguments.of("description", LocalDateTime.now(),
+                            LocalDateTime.now().plusDays(1), "attributeName", " ")
             );
 
         }
@@ -202,86 +213,122 @@ public class PromotionIntegrationTest {
     @DisplayName("프로모션 조회 테스트")
     class RetrieveActivePromotionsTests {
 
-        @DisplayName("요청된 기간 내 유효한 프로모션 전체 조회")
+        @DisplayName("현재 시간 기준 유효한 프로모션 전체 조회")
         @TestFactory
-        Stream<DynamicTest> givenTimePeriod_whenRetrievePromotions_thenAllActivePromotionsAreListed() {
-
-            final PromotionEntity[] savedPromotion1 = new PromotionEntity[1];
-            final PromotionEntity[] savedPromotion2 = new PromotionEntity[1];
-
-            final PromotionAttributeEntity[] savedPromotionAttribute1 = new PromotionAttributeEntity[1];
-            final PromotionAttributeEntity[] savedPromotionAttribute2 = new PromotionAttributeEntity[1];
-
+        Stream<DynamicTest> whenCurrentTimeGiven_thenListActivePromotionsPaged() {
             return Stream.of(
                     DynamicTest.dynamicTest("1. 프로모션1 저장 ->", () -> {
                         // given
                         PromotionEntity promotionEntity = PromotionEntity.builder()
                                 .description("여름 프로모션")
-                                .startDate(LocalDateTime.of(2024, 5, 4, 0, 0, 0))
+                                .startDate(LocalDateTime.of(2024, 5, 13, 23, 44, 0))
                                 .endDate(LocalDateTime.of(2024, 7, 1, 0, 0, 0))
                                 .build();
+                        PromotionEntity savedPromotion1 = promotionRepository.save(promotionEntity);
+                        assertNotNull(savedPromotion1.getId());
 
-                        savedPromotion1[0] = promotionRepository.save(promotionEntity);
-                        assertNotNull(savedPromotion1[0].getId());
-
-                        PromotionAttributeEntity promotionAttributeEntity = PromotionAttributeEntity.builder()
-                                .promotionEntity(savedPromotion1[0])
+                        PromotionAttributeEntity promotionAttributeEntity =
+                                PromotionAttributeEntity.builder()
+                                .promotionEntity(savedPromotion1)
                                 .attributeName("target-month")
                                 .attributeValue("6")
                                 .build();
-
-                        savedPromotionAttribute1[0] = promotionAttributeRepository.save(promotionAttributeEntity);
-                        assertNotNull(savedPromotionAttribute1[0].getId());
+                        promotionAttributeRepository.save(promotionAttributeEntity);
 
                     }), DynamicTest.dynamicTest("2. 프로모션2 저장 ->", () -> {
                         // given
                         PromotionEntity promotionEntity = PromotionEntity.builder()
-                                .description("여름 앵콜 프로모션")
-                                .startDate(LocalDateTime.of(2024, 5, 3, 0, 0, 0))
-                                .endDate(LocalDateTime.of(2024, 7, 3, 0, 0, 0))
+                                .description("스릴러 프로모션")
+                                .startDate(LocalDateTime.of(2024, 5, 13, 23, 44, 0))
+                                .endDate(LocalDateTime.of(2024, 7, 1, 0, 0, 0))
                                 .build();
+                        PromotionEntity savedPromotion2 = promotionRepository.save(promotionEntity);
+                        assertNotNull(savedPromotion2.getId());
 
-                        savedPromotion2[0] = promotionRepository.save(promotionEntity);
-                        assertNotNull(savedPromotion2[0].getId());
-
-                        PromotionAttributeEntity promotionAttributeEntity = PromotionAttributeEntity.builder()
-                                .promotionEntity(savedPromotion2[0])
+                        PromotionAttributeEntity promotionAttributeEntity =
+                                PromotionAttributeEntity.builder()
+                                .promotionEntity(savedPromotion2)
                                 .attributeName("target-genre")
-                                .attributeValue("스릴러")
+                                .attributeValue("thriller")
                                 .build();
-
-                        savedPromotionAttribute2[0] = promotionAttributeRepository.save(promotionAttributeEntity);
-                        assertNotNull(savedPromotionAttribute2[0].getId());
+                        promotionAttributeRepository.save(promotionAttributeEntity);
 
                     }), DynamicTest.dynamicTest("3. 유효한 프로모션 조회", () -> {
-                        // given
-                        final RetrieveActivePromotionsRequest request = new RetrieveActivePromotionsRequest(
-                                LocalDateTime.of(2024, 5, 2, 0, 0, 0),
-                                LocalDateTime.of(2024, 5, 5, 0, 0, 0)
-                        );
-                        final String requestBody = objectMapper.writeValueAsString(request);
-
                         // when, then
                         mockMvc.perform(get("/v1/promotions/now")
-                                        .content(requestBody)
                                         .contentType(MediaType.APPLICATION_JSON))
                                 .andExpect(status().isOk())
                                 .andExpect(jsonPath("$.statusMessage").value("성공"))
-                                .andExpect(jsonPath("$.data.content[0].promotionId").value(savedPromotion1[0].getId()))
-                                .andExpect(jsonPath("$.data.content[0].description").value("여름 프로모션"))
-                                .andExpect(jsonPath("$.data.content[0].startDate").value("2024-05-04T00:00:00"))
-                                .andExpect(jsonPath("$.data.content[0].endDate").value("2024-07-01T00:00:00"))
-                                .andExpect(jsonPath("$.data.content[0].attributeName").value("target-month"))
+                                .andExpect(jsonPath("$.data.content[0].description").value("여름 " +
+                                        "프로모션"))
+                                .andExpect(jsonPath("$.data.content[0].startDate").value("2024-05" +
+                                        "-13T23:44:00"))
+                                .andExpect(jsonPath("$.data.content[0].endDate").value("2024-07" +
+                                        "-01T00:00:00"))
+                                .andExpect(jsonPath("$.data.content[0].attributeName").value(
+                                        "target-month"))
                                 .andExpect(jsonPath("$.data.content[0].attributeValue").value("6"))
-                                .andExpect(jsonPath("$.data.content[1].promotionId").value(savedPromotion2[0].getId()))
-                                .andExpect(jsonPath("$.data.content[1].description").value("여름 앵콜 프로모션"))
-                                .andExpect(jsonPath("$.data.content[1].startDate").value("2024-05-03T00:00:00"))
-                                .andExpect(jsonPath("$.data.content[1].endDate").value("2024-07-03T00:00:00"))
-                                .andExpect(jsonPath("$.data.content[1].attributeName").value("target-genre"))
-                                .andExpect(jsonPath("$.data.content[1].attributeValue").value("스릴러"));
+                                .andExpect(jsonPath("$.data.content[1].description").value("스릴러 " +
+                                        "프로모션"))
+                                .andExpect(jsonPath("$.data.content[1].startDate").value("2024-05" +
+                                        "-13T23:44:00"))
+                                .andExpect(jsonPath("$.data.content[1].endDate").value("2024-07" +
+                                        "-01T00:00:00"))
+                                .andExpect(jsonPath("$.data.content[1].attributeName").value(
+                                        "target-genre"))
+                                .andExpect(jsonPath("$.data.content[1].attributeValue").value(
+                                        "thriller"));
                     })
             );
+        }
 
+        @DisplayName("현재 시간 기준 유효한 프로모션 조회 - 등록된 프로모션이 현재 시간에는 유효하지 않을 경우 빈 페이지 반환")
+        @TestFactory
+        Stream<DynamicTest> whenCurrentTimeGiven_AndNoPromotions_thenReturnEmptyPage() throws Exception {
+            return Stream.of(
+                    DynamicTest.dynamicTest("1. 과거 프로모션1 저장 ->", () -> {
+                        // given
+                        PromotionEntity promotionEntity = PromotionEntity.builder()
+                                .description("여름 프로모션")
+                                .startDate(LocalDateTime.of(2024, 1, 1, 0, 0, 0))
+                                .endDate(LocalDateTime.of(2024, 5, 1, 0, 0, 0))
+                                .build();
+                        PromotionEntity savedPromotion1 = promotionRepository.save(promotionEntity);
+
+                        PromotionAttributeEntity promotionAttributeEntity =
+                                PromotionAttributeEntity.builder()
+                                .promotionEntity(savedPromotion1)
+                                .attributeName("target-month")
+                                .attributeValue("6")
+                                .build();
+                        promotionAttributeRepository.save(promotionAttributeEntity);
+
+                    }), DynamicTest.dynamicTest("2. 과거 프로모션2 저장 ->", () -> {
+                        // given
+                        PromotionEntity promotionEntity = PromotionEntity.builder()
+                                .description("스릴러 프로모션")
+                                .startDate(LocalDateTime.of(2024, 2, 1, 0, 0, 0))
+                                .endDate(LocalDateTime.of(2024, 5, 1, 0, 0, 0))
+                                .build();
+                        PromotionEntity savedPromotion2 = promotionRepository.save(promotionEntity);
+
+                        PromotionAttributeEntity promotionAttributeEntity =
+                                PromotionAttributeEntity.builder()
+                                .promotionEntity(savedPromotion2)
+                                .attributeName("target-genre")
+                                .attributeValue("thriller")
+                                .build();
+                        promotionAttributeRepository.save(promotionAttributeEntity);
+
+                    }), DynamicTest.dynamicTest("3. 유효한 프로모션 조회", () -> {
+                        // when, then
+                        mockMvc.perform(get("/v1/promotions/now")
+                                        .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.statusMessage").value("성공"))
+                                .andExpect(jsonPath("$.data.content").isEmpty());
+                    })
+            );
         }
 
     }


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 현재 활성화된 프로모션이 없을 경우 404 에러 대신 빈 페이지 반환하도록 수정했습니다.
- [x] 기존의 프로모션 전체 조회 테스트 코드를 보다 명확하게 수정하고 현재 시간을 기준으로 유효한 프로모션이 없을 경우 빈 페이지를 반환하는 새로운 통합 테스트 메서드를 추가했습니다.

## 💡️ 이슈

## 📢 논의하고 싶은 내용
- PromotionRepository에 현재 활성화된 모든 프로모션을 조회하는 두 쿼리가 있습니다. activePromotions는 쿠키 결제에 사용되고 있고, findActivePromotions는 프로모션 전체 조회 구현에 사용되고 있습니다. 다음 회의 시간에 관련해서 쿼리를 하나로 합칠 지 아니면 분리해서 가져갈지 논의해보고싶습니다. 🔥
<img width="1023" alt="image" src="https://github.com/FreakPeople/freak-devtoon/assets/78125105/efe9458f-ab66-4cc3-8dcd-68c372340abf">
