### PR TITLE
refactor: 비즈니스 로직의 return값을 도메인으로 변경

### DIFF
--- a/src/main/java/yjh/devtoon/payment/application/CookiePaymentService.java
+++ b/src/main/java/yjh/devtoon/payment/application/CookiePaymentService.java
@@ -13,7 +13,6 @@ import yjh.devtoon.cookie_wallet.infrastructure.CookieWalletRepository;
 import yjh.devtoon.payment.constant.ErrorMessage;
 import yjh.devtoon.payment.domain.CookiePaymentEntity;
 import yjh.devtoon.payment.domain.Price;
-import yjh.devtoon.payment.dto.CookiePaymentDetailDto;
 import yjh.devtoon.payment.dto.request.CookiePaymentCreateRequest;
 import yjh.devtoon.payment.infrastructure.CookiePaymentRepository;
 import yjh.devtoon.policy.infrastructure.CookiePolicyRepository;
@@ -42,7 +41,6 @@ public class CookiePaymentService {
      */
     @Transactional
     public void register(final CookiePaymentCreateRequest request) {
-
         // 1. webtoonViewerId가 DB에 존재하는지 확인
         Long webtoonViewerId = getWebtoonViewerIdOrThrow(request.getWebtoonViewerId());
 
@@ -73,7 +71,6 @@ public class CookiePaymentService {
         CookieWalletEntity cookieWallet = cookieWalletService.retrieve(webtoonViewerId);
         cookieWallet.increase(quantity);
         cookieWalletRepository.save(cookieWallet);
-
     }
 
     private Long getWebtoonViewerIdOrThrow(final Long webtoonViewerId) {
@@ -81,7 +78,7 @@ public class CookiePaymentService {
                 .orElseThrow(() -> new DevtoonException(
                         ErrorCode.NOT_FOUND,
                         ErrorMessage.getResourceNotFound(ResourceType.WEBTOON_VIEWER,
-                        webtoonViewerId))
+                                webtoonViewerId))
                 ).getId();
     }
 
@@ -102,22 +99,13 @@ public class CookiePaymentService {
     /**
      * 특정 회원 쿠키 결제 내역 조회
      */
-    public CookiePaymentDetailDto retrieve(final Long webtoonViewerId) {
-        CookiePaymentEntity cookiePayment =
-                cookiePaymentRepository.findByWebtoonViewerId(webtoonViewerId)
-                        .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND,
-                                ErrorMessage.getResourceNotFound(ResourceType.COOKIE_PAYMENT,
-                                        webtoonViewerId)));
-
-        Price totalPrice = cookiePayment.calculateTotalPrice();
-        Price paymentPrice = cookiePayment.calculatePaymentPrice();
-
-        return new CookiePaymentDetailDto(
-                cookiePayment,
-                totalPrice,
-                paymentPrice
-        );
-
+    public CookiePaymentEntity retrieve(final Long webtoonViewerId) {
+        return cookiePaymentRepository.findByWebtoonViewerId(webtoonViewerId)
+                .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND,
+                        ErrorMessage.getResourceNotFound(
+                                ResourceType.COOKIE_PAYMENT,
+                                webtoonViewerId
+                        )));
     }
 
 }

--- a/src/main/java/yjh/devtoon/payment/dto/CookiePaymentDetailDto.java
+++ b/src/main/java/yjh/devtoon/payment/dto/CookiePaymentDetailDto.java
@@ -13,4 +13,12 @@ public class CookiePaymentDetailDto {
     private final Price totalPrice;
     private final Price paymentPrice;
 
+    public static CookiePaymentDetailDto from(final CookiePaymentEntity cookiePayment) {
+        return new CookiePaymentDetailDto(
+                cookiePayment,
+                cookiePayment.calculateTotalPrice(),
+                cookiePayment.calculatePaymentPrice()
+        );
+    }
+
 }

--- a/src/main/java/yjh/devtoon/payment/dto/response/CookiePaymentRetrieveResponse.java
+++ b/src/main/java/yjh/devtoon/payment/dto/response/CookiePaymentRetrieveResponse.java
@@ -15,17 +15,33 @@ public class CookiePaymentRetrieveResponse {
     private BigDecimal paymentPrice;       // 결제 금액 = totalPrice * (1-totalDiscountRate)
     private LocalDateTime createdAt;
 
+    public CookiePaymentRetrieveResponse(
+            Long webtoonViewerNo,
+            Integer quantity,
+            BigDecimal totalPrice,
+            BigDecimal totalDiscountRate,
+            BigDecimal paymentPrice,
+            LocalDateTime createdAt
+    ) {
+        this.webtoonViewerNo = webtoonViewerNo;
+        this.quantity = quantity;
+        this.totalPrice = totalPrice;
+        this.totalDiscountRate = totalDiscountRate;
+        this.paymentPrice = paymentPrice;
+        this.createdAt = createdAt;
+    }
+
     public static CookiePaymentRetrieveResponse from(
             final CookiePaymentDetailDto cookiePaymentDetailDto
     ) {
-        CookiePaymentRetrieveResponse response = new CookiePaymentRetrieveResponse();
-        response.webtoonViewerNo = cookiePaymentDetailDto.getCookiePayment().getWebtoonViewerId();
-        response.quantity = cookiePaymentDetailDto.getCookiePayment().getQuantity();
-        response.totalPrice = cookiePaymentDetailDto.getTotalPrice().getAmount();
-        response.totalDiscountRate = cookiePaymentDetailDto.getCookiePayment().getTotalDiscountRate();
-        response.paymentPrice = cookiePaymentDetailDto.getPaymentPrice().getAmount();
-        response.createdAt = cookiePaymentDetailDto.getCookiePayment().getCreatedAt();
-        return response;
+        return new CookiePaymentRetrieveResponse(
+                cookiePaymentDetailDto.getCookiePayment().getWebtoonViewerId(),
+                cookiePaymentDetailDto.getCookiePayment().getQuantity(),
+                cookiePaymentDetailDto.getTotalPrice().getAmount(),
+                cookiePaymentDetailDto.getCookiePayment().getTotalDiscountRate(),
+                cookiePaymentDetailDto.getPaymentPrice().getAmount(),
+                cookiePaymentDetailDto.getCookiePayment().getCreatedAt()
+        );
     }
 
 }

--- a/src/main/java/yjh/devtoon/payment/presentation/CookiePaymentController.java
+++ b/src/main/java/yjh/devtoon/payment/presentation/CookiePaymentController.java
@@ -1,6 +1,7 @@
 package yjh.devtoon.payment.presentation;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,10 +11,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yjh.devtoon.common.response.ApiReponse;
 import yjh.devtoon.payment.application.CookiePaymentService;
+import yjh.devtoon.payment.domain.CookiePaymentEntity;
 import yjh.devtoon.payment.dto.CookiePaymentDetailDto;
 import yjh.devtoon.payment.dto.request.CookiePaymentCreateRequest;
 import yjh.devtoon.payment.dto.response.CookiePaymentRetrieveResponse;
 
+@Slf4j
 @RequestMapping("/v1/cookie-payments")
 @RequiredArgsConstructor
 @RestController
@@ -40,8 +43,11 @@ public class CookiePaymentController {
     public ResponseEntity<ApiReponse> retrieve(
             @PathVariable final Long webtoonViewerId
     ) {
-        CookiePaymentDetailDto cookiePaymentDetailDto = cookiePaymentService.retrieve(webtoonViewerId);
-        CookiePaymentRetrieveResponse response = CookiePaymentRetrieveResponse.from(cookiePaymentDetailDto);
+        CookiePaymentEntity cookiePayment = cookiePaymentService.retrieve(webtoonViewerId);
+        CookiePaymentDetailDto cookiePaymentDetailDto = CookiePaymentDetailDto.from(cookiePayment);
+        CookiePaymentRetrieveResponse response =
+                CookiePaymentRetrieveResponse.from(cookiePaymentDetailDto);
+
         return ResponseEntity.ok(ApiReponse.success(response));
     }
 

--- a/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
+++ b/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
@@ -14,7 +14,6 @@ import yjh.devtoon.promotion.constant.ErrorMessage;
 import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
 import yjh.devtoon.promotion.domain.PromotionEntity;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
-import yjh.devtoon.promotion.dto.response.PromotionSoftDeleteResponse;
 import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionsResponse;
 import yjh.devtoon.promotion.infrastructure.PromotionAttributeRepository;
 import yjh.devtoon.promotion.infrastructure.PromotionRepository;
@@ -50,18 +49,19 @@ public class PromotionService {
     }
 
     /**
-     * 프로모션 소프트 삭제
+     * 프로모션 삭제
+     * : 삭제 시간을 통해 로직상에서 삭제 처리를 구분합니다.
      */
     @Transactional
-    public PromotionSoftDeleteResponse softDelete(final Long id) {
+    public PromotionEntity delete(final Long id) {
         PromotionEntity promotion = promotionRepository.findById(id)
-                .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND,
-                        ErrorMessage.getResourceNotFound(ResourceType.PROMOTION, id)));
-
+                .orElseThrow(() -> new DevtoonException(
+                        ErrorCode.NOT_FOUND,
+                        ErrorMessage.getResourceNotFound(ResourceType.PROMOTION, id)
+                ));
         promotion.recordDeletion(LocalDateTime.now());
-        PromotionEntity softDeletedPromotion = promotionRepository.save(promotion);
 
-        return PromotionSoftDeleteResponse.from(softDeletedPromotion);
+        return promotionRepository.save(promotion);
     }
 
     /**

--- a/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
+++ b/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
@@ -14,7 +14,6 @@ import yjh.devtoon.promotion.constant.ErrorMessage;
 import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
 import yjh.devtoon.promotion.domain.PromotionEntity;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
-import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionsResponse;
 import yjh.devtoon.promotion.infrastructure.PromotionAttributeRepository;
 import yjh.devtoon.promotion.infrastructure.PromotionRepository;
 import java.time.LocalDateTime;
@@ -69,18 +68,9 @@ public class PromotionService {
      * : 현재 활성화된 프로모션이 없는 경우 빈 페이지를 반환합니다.
      */
     @Transactional(readOnly = true)
-    public Page<RetrieveActivePromotionsResponse> retrieveActivePromotions(
-            final Pageable pageable
-    ) {
-        // 활성화된 프로모션 목록 조회
+    public Page<PromotionEntity> retrieveActivePromotions(final Pageable pageable) {
         Page<PromotionEntity> activePromotions = validateActivePromotionExists(pageable);
-
-        // 각 프로모션 엔티티를 프로모션 속성과 함께 응답 객체로 변환
-        return activePromotions.map(promotionEntity -> {
-            PromotionAttributeEntity promotionAttribute =
-                    validatePromotionAttributeExists(promotionEntity);
-            return RetrieveActivePromotionsResponse.from(promotionEntity, promotionAttribute);
-        });
+        return activePromotions;
     }
 
     private Page<PromotionEntity> validateActivePromotionExists(final Pageable pageable) {
@@ -95,12 +85,13 @@ public class PromotionService {
         return promotions;
     }
 
-    private PromotionAttributeEntity validatePromotionAttributeExists(
+    public PromotionAttributeEntity validatePromotionAttributeExists(
             final PromotionEntity promotionEntity
     ) {
         PromotionAttributeEntity promotionAttribute =
                 promotionAttributeRepository.findByPromotionEntityId(promotionEntity.getId())
-                        .orElseThrow(() -> new DevtoonException(ErrorCode.NOT_FOUND,
+                        .orElseThrow(() -> new DevtoonException(
+                                ErrorCode.NOT_FOUND,
                                 ErrorMessage.getResourceNotFound(
                                         ResourceType.PROMOTION,
                                         promotionEntity.getId()

--- a/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
+++ b/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yjh.devtoon.common.response.ApiReponse;
 import yjh.devtoon.promotion.application.PromotionService;
+import yjh.devtoon.promotion.domain.PromotionEntity;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
 import yjh.devtoon.promotion.dto.response.PromotionSoftDeleteResponse;
 import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionsResponse;
@@ -40,12 +41,14 @@ public class PromotionController {
 
     /**
      * 프로모션 삭제
+     * : 삭제 시간을 통해 로직상에서 삭제 처리를 구분합니다.
      */
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiReponse> softDelete(
+    public ResponseEntity<ApiReponse> delete(
             @PathVariable final Long id
     ) {
-        PromotionSoftDeleteResponse response = promotionService.softDelete(id);
+        PromotionEntity promotionEntity = promotionService.delete(id);
+        PromotionSoftDeleteResponse response = PromotionSoftDeleteResponse.from(promotionEntity);
         return ResponseEntity.ok(ApiReponse.success(response));
     }
 

--- a/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
+++ b/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yjh.devtoon.common.response.ApiReponse;
 import yjh.devtoon.promotion.application.PromotionService;
+import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
 import yjh.devtoon.promotion.domain.PromotionEntity;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
 import yjh.devtoon.promotion.dto.response.PromotionSoftDeleteResponse;
@@ -58,11 +59,21 @@ public class PromotionController {
      */
     @GetMapping("/now")
     public ResponseEntity<ApiReponse<Page<RetrieveActivePromotionsResponse>>> retrieveActivePromotions(
-            Pageable pageable
+            final Pageable pageable
     ) {
-        Page<RetrieveActivePromotionsResponse> activePromotions =
+        Page<PromotionEntity> activePromotions =
                 promotionService.retrieveActivePromotions(pageable);
-        return ResponseEntity.ok(ApiReponse.success(activePromotions));
+
+        Page<RetrieveActivePromotionsResponse> response =
+                activePromotions.map(promotionEntity -> {
+                    PromotionAttributeEntity promotionAttribute =
+                            promotionService.validatePromotionAttributeExists(promotionEntity);
+                    return RetrieveActivePromotionsResponse.from(
+                            promotionEntity,
+                            promotionAttribute
+                    );
+                });
+        return ResponseEntity.ok(ApiReponse.success(response));
     }
 
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 비즈니스 로직의 return값을 도메인으로 변경
  - [x] 특정 회원 쿠키 결제 내역 조회 
  - [x] 프로모션 삭제
  - [x] 현재 활성화된 프로모션 전체 조회 

## 💡️ 이슈
- 서비스 메서드를 사용하기 위해 접근제어자를 private에서 public으로 수정하여 서비스 메서드 사용이 가능하도록 변경했습니다. 
아래 사진은 PromotionService에 있는 메서드입니다.
<img width="767" alt="image" src="https://github.com/FreakPeople/freak-devtoon/assets/78125105/b4b8d363-d9ec-4032-b780-4320e24b19d4">

## 📢 논의하고 싶은 내용
- 해당 이슈와 관련하여 접근제어자를 public으로 수정하는 대신, 다른 접근 제어 전략이나 리팩토링 방법이 있을지 다음 회의 때 논의해보고 싶습니다. 😀