### PR TITLE
fix: 프로모션 조회 로직 수정

### DIFF
--- a/src/main/java/yjh/devtoon/bad_words_warning_count/presentation/BadWordsWarningCountController.java
+++ b/src/main/java/yjh/devtoon/bad_words_warning_count/presentation/BadWordsWarningCountController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import yjh.devtoon.bad_words_warning_count.aplication.BadWordsWarningCountService;
 import yjh.devtoon.bad_words_warning_count.domain.BadWordsWarningCountEntity;
 import yjh.devtoon.bad_words_warning_count.dto.response.BadWordsWarningCountResponse;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 
 @RequestMapping("/v1/bad-words-warning-count")
 @RequiredArgsConstructor
@@ -23,24 +23,24 @@ public class BadWordsWarningCountController {
      * 비속어 카운트 조회
      */
     @GetMapping
-    public ResponseEntity<ApiReponse> retrieve(
+    public ResponseEntity<ApiResponse> retrieve(
             @RequestParam("webtoonViewerNo") final Long id
     ) {
         BadWordsWarningCountEntity badWordsWarningCount = badWordsWarningCountService.retrieve(id);
         BadWordsWarningCountResponse response = BadWordsWarningCountResponse.from(badWordsWarningCount);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 비속어 카운트 증가
      */
     @PutMapping("/increase")
-    public ResponseEntity<ApiReponse> increase(
+    public ResponseEntity<ApiResponse> increase(
             @RequestParam("webtoonViewerNo") final Long id
     ) {
         BadWordsWarningCountEntity badWordsWarningCount = badWordsWarningCountService.increase(id);
         BadWordsWarningCountResponse response = BadWordsWarningCountResponse.from(badWordsWarningCount);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/yjh/devtoon/comment/presentation/CommentController.java
+++ b/src/main/java/yjh/devtoon/comment/presentation/CommentController.java
@@ -13,7 +13,7 @@ import yjh.devtoon.comment.application.CommentService;
 import yjh.devtoon.comment.domain.CommentEntity;
 import yjh.devtoon.comment.dto.reponse.CommentResponse;
 import yjh.devtoon.comment.dto.request.CommentCreateRequest;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 
 @RequestMapping("/v1/comments")
 @RequiredArgsConstructor
@@ -26,23 +26,23 @@ public class CommentController {
      * 댓글 등록
      */
     @PostMapping
-    public ResponseEntity<ApiReponse> register(
+    public ResponseEntity<ApiResponse> register(
             @RequestBody @Valid final CommentCreateRequest request
     ) {
         commentService.create(request);
-        return ResponseEntity.ok(ApiReponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 댓글 조회
      */
     @GetMapping("/{id}")
-    public ResponseEntity<ApiReponse> retrieve(
+    public ResponseEntity<ApiResponse> retrieve(
             @PathVariable final Long id
     ) {
         CommentEntity comment = commentService.retrieve(id);
         CommentResponse response = CommentResponse.from(comment);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/yjh/devtoon/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/yjh/devtoon/common/exception/GlobalControllerAdvice.java
@@ -7,9 +7,8 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.common.utils.DateFormatter;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -17,7 +16,7 @@ import java.util.List;
 public class GlobalControllerAdvice {
 
     @ExceptionHandler(DevtoonException.class)
-    public ResponseEntity<ApiReponse> applicationHandler(final DevtoonException e) {
+    public ResponseEntity<ApiResponse> applicationHandler(final DevtoonException e) {
         int statusCode = e.getErrorCode().getStatus().value();
         String currentTime = DateFormatter.getCurrentDateTime();
         String message = e.getErrorCode().getMessage();
@@ -27,11 +26,11 @@ public class GlobalControllerAdvice {
 
         log.error("Error: {} {} -> {}", statusCode, message, detailMessage);
 
-        return ResponseEntity.ok(ApiReponse.error(errorData));
+        return ResponseEntity.ok(ApiResponse.error(errorData));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiReponse> validationHandler(final MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse> validationHandler(final MethodArgumentNotValidException e) {
 
         List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
         List<String> errors = fieldErrors.stream()
@@ -48,11 +47,11 @@ public class GlobalControllerAdvice {
 
         log.error("Error: {} {} -> {}", HttpStatus.BAD_REQUEST.value(), e.getClass().getSimpleName(), errors);
 
-        return ResponseEntity.ok(ApiReponse.error(errorData));
+        return ResponseEntity.ok(ApiResponse.error(errorData));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiReponse> InternalExceptionHandler(final Exception e) {
+    public ResponseEntity<ApiResponse> InternalExceptionHandler(final Exception e) {
 
         ErrorData errorData = new ErrorData(
                 HttpStatus.INTERNAL_SERVER_ERROR.value(),
@@ -64,7 +63,7 @@ public class GlobalControllerAdvice {
         log.error("Error: {} {} -> {}",
                 HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR.name(), e.getMessage());
 
-        return ResponseEntity.ok(ApiReponse.error(errorData));
+        return ResponseEntity.ok(ApiResponse.error(errorData));
     }
 
 }

--- a/src/main/java/yjh/devtoon/common/response/ApiResponse.java
+++ b/src/main/java/yjh/devtoon/common/response/ApiResponse.java
@@ -3,27 +3,27 @@ package yjh.devtoon.common.response;
 import lombok.Getter;
 
 @Getter
-public class ApiReponse<T> {
+public class ApiResponse<T> {
 
     private final String statusMessage;
     private final T data;
 
-    public ApiReponse(
+    public ApiResponse(
             final String statusMessage,
             final T data) {
         this.statusMessage = statusMessage;
         this.data = data;
     }
 
-    public static <T> ApiReponse<T> success(final T data) {
-        return new ApiReponse<>(
+    public static <T> ApiResponse<T> success(final T data) {
+        return new ApiResponse<>(
                 "성공",
                 data
         );
     }
 
-    public static <T> ApiReponse<T> error(final T data) {
-        return new ApiReponse<>(
+    public static <T> ApiResponse<T> error(final T data) {
+        return new ApiResponse<>(
                 "실패",
                 data
         );

--- a/src/main/java/yjh/devtoon/cookie_wallet/presentation/CookieWalletController.java
+++ b/src/main/java/yjh/devtoon/cookie_wallet/presentation/CookieWalletController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.cookie_wallet.application.CookieWalletService;
 import yjh.devtoon.cookie_wallet.domain.CookieWalletEntity;
 import yjh.devtoon.cookie_wallet.dto.request.CookieRequest;
@@ -25,38 +25,38 @@ public class CookieWalletController {
      * 쿠키 지갑 조회
      */
     @GetMapping
-    public ResponseEntity<ApiReponse> retrieve(
+    public ResponseEntity<ApiResponse> retrieve(
             @RequestParam("webtoonViewerNo") final Long id
     ) {
         CookieWalletEntity cookieWallet = cookieWalletService.retrieve(id);
         CookieWalletResponse response = CookieWalletResponse.from(cookieWallet);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 쿠키 증가
      */
     @PutMapping("/increase")
-    public ResponseEntity<ApiReponse> increase(
+    public ResponseEntity<ApiResponse> increase(
             @RequestParam("webtoonViewerNo") final Long id,
             @RequestBody final CookieRequest request
     ) {
         CookieWalletEntity cookieWallet = cookieWalletService.increase(id, request);
         CookieWalletResponse response = CookieWalletResponse.from(cookieWallet);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 쿠키 감소
      */
     @PutMapping("/decrease")
-    public ResponseEntity<ApiReponse> decrease(
+    public ResponseEntity<ApiResponse> decrease(
             @RequestParam("webtoonViewerNo") final Long id,
             @RequestBody final CookieRequest request
     ) {
         CookieWalletEntity cookieWallet = cookieWalletService.decrease(id, request);
         CookieWalletResponse response = CookieWalletResponse.from(cookieWallet);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/yjh/devtoon/payment/application/CookiePaymentService.java
+++ b/src/main/java/yjh/devtoon/payment/application/CookiePaymentService.java
@@ -49,7 +49,7 @@ public class CookiePaymentService {
         Price activeCookie = Price.of(cookiePolicyRepository.activeCookiePrice(now));
 
         // 3. 현재 활성 프로모션 조회
-        List<PromotionEntity> activePromotions = promotionRepository.activePromotions(now);
+        List<PromotionEntity> activePromotions = promotionRepository.findActivePromotions(now);
 
         // 4. 쿠키 결제 가격 계산 - 요청한 쿠키 개수 * 현재 쿠키 가격 - 프로모션 할인율(회원등급,각종 프로모션 적용)
         BigDecimal totalDiscountRate = calculateTotalDiscountRate(activePromotions);

--- a/src/main/java/yjh/devtoon/payment/presentation/CookiePaymentController.java
+++ b/src/main/java/yjh/devtoon/payment/presentation/CookiePaymentController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.payment.application.CookiePaymentService;
 import yjh.devtoon.payment.domain.CookiePaymentEntity;
 import yjh.devtoon.payment.dto.CookiePaymentDetailDto;
@@ -29,18 +29,18 @@ public class CookiePaymentController {
      * : 쿠키는 현금으로 결제한다.
      */
     @PostMapping
-    public ResponseEntity<ApiReponse> register(
+    public ResponseEntity<ApiResponse> register(
             @RequestBody final CookiePaymentCreateRequest request
     ) {
         cookiePaymentService.register(request);
-        return ResponseEntity.ok(ApiReponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 특정 회원 쿠키 결제 내역 단건 조회
      */
     @GetMapping("/{webtoonViewerId}")
-    public ResponseEntity<ApiReponse> retrieve(
+    public ResponseEntity<ApiResponse> retrieve(
             @PathVariable final Long webtoonViewerId
     ) {
         CookiePaymentEntity cookiePayment = cookiePaymentService.retrieve(webtoonViewerId);
@@ -48,7 +48,7 @@ public class CookiePaymentController {
         CookiePaymentRetrieveResponse response =
                 CookiePaymentRetrieveResponse.from(cookiePaymentDetailDto);
 
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/yjh/devtoon/payment/presentation/WebtoonPaymentController.java
+++ b/src/main/java/yjh/devtoon/payment/presentation/WebtoonPaymentController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.payment.application.WebtoonPaymentService;
 import yjh.devtoon.payment.domain.WebtoonPaymentEntity;
 import yjh.devtoon.payment.dto.request.WebtoonPaymentCreateRequest;
@@ -26,23 +26,23 @@ public class WebtoonPaymentController {
      * : 웹툰 미리보기는 쿠키로 결제한다.
      */
     @PostMapping
-    public ResponseEntity<ApiReponse> register(
+    public ResponseEntity<ApiResponse> register(
             @RequestBody final WebtoonPaymentCreateRequest request
     ) {
         webtoonPaymentService.register(request);
-        return ResponseEntity.ok(ApiReponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 특정 회원 웹툰 결제 내역 단건 조회
      */
     @GetMapping("/{webtoonViewerId}")
-    public ResponseEntity<ApiReponse> retrieve(
+    public ResponseEntity<ApiResponse> retrieve(
             @PathVariable final Long webtoonViewerId
     ) {
         WebtoonPaymentEntity webtoonPayment = webtoonPaymentService.retrieve(webtoonViewerId);
         WebtoonPaymentRetrieveResponse response = WebtoonPaymentRetrieveResponse.from(webtoonPayment);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/yjh/devtoon/policy/presentation/PoilcyController.java
+++ b/src/main/java/yjh/devtoon/policy/presentation/PoilcyController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.policy.application.PolicyService;
 import yjh.devtoon.policy.dto.request.PolicyCreateRequest;
 
@@ -23,11 +23,11 @@ public class PoilcyController {
      * 정책 등록
      */
     @PostMapping
-    public ResponseEntity<ApiReponse> register(
+    public ResponseEntity<ApiResponse> register(
             @RequestBody final PolicyCreateRequest request
     ) {
         policyService.register(request);
-        return ResponseEntity.ok(ApiReponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**

--- a/src/main/java/yjh/devtoon/promotion/dto/response/RetrieveActivePromotionAttributesResponse.java
+++ b/src/main/java/yjh/devtoon/promotion/dto/response/RetrieveActivePromotionAttributesResponse.java
@@ -1,0 +1,27 @@
+package yjh.devtoon.promotion.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
+
+@AllArgsConstructor
+@Getter
+public class RetrieveActivePromotionAttributesResponse {
+
+    private final Long attributeId;
+    private final Long promotionId;
+    private final String attributeName;
+    private final String attributeValue;
+
+    public static RetrieveActivePromotionAttributesResponse from(
+            final PromotionAttributeEntity promotionAttributeEntity
+    ) {
+        return new RetrieveActivePromotionAttributesResponse(
+                promotionAttributeEntity.getId(),
+                promotionAttributeEntity.getPromotionEntity().getId(),
+                promotionAttributeEntity.getAttributeName(),
+                promotionAttributeEntity.getAttributeValue()
+        );
+    }
+
+}

--- a/src/main/java/yjh/devtoon/promotion/dto/response/RetrieveActivePromotionsResponse.java
+++ b/src/main/java/yjh/devtoon/promotion/dto/response/RetrieveActivePromotionsResponse.java
@@ -2,8 +2,9 @@ package yjh.devtoon.promotion.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
+import yjh.devtoon.promotion.domain.DiscountType;
 import yjh.devtoon.promotion.domain.PromotionEntity;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
@@ -12,35 +13,26 @@ public class RetrieveActivePromotionsResponse {
 
     private final Long promotionId;
     private final String description;
+    private final DiscountType discountType;
+    private final BigDecimal discountRate;
+    private final Integer discountQuantity;
+    private final Boolean isDiscountDuplicatable;
     private final LocalDateTime startDate;
     private final LocalDateTime endDate;
-    private final String attributeName;
-    private final String attributeValue;
 
     public static RetrieveActivePromotionsResponse from(
-            final PromotionEntity promotionEntity,
-            final PromotionAttributeEntity promotionAttributeEntity
+            final PromotionEntity promotionEntity
     ) {
         return new RetrieveActivePromotionsResponse(
                 promotionEntity.getId(),
                 promotionEntity.getDescription(),
+                promotionEntity.getDiscountType(),
+                promotionEntity.getDiscountRate(),
+                promotionEntity.getDiscountQuantity(),
+                promotionEntity.getIsDiscountDuplicatable(),
                 promotionEntity.getStartDate(),
-                promotionEntity.getEndDate(),
-                promotionAttributeEntity.getAttributeName(),
-                promotionAttributeEntity.getAttributeValue()
+                promotionEntity.getEndDate()
         );
-    }
-
-    @Override
-    public String toString() {
-        return "PromotionListResponse{" +
-                "promotionId=" + promotionId +
-                ", description='" + description + '\'' +
-                ", startDate=" + startDate +
-                ", endDate=" + endDate +
-                ", attributeName='" + attributeName + '\'' +
-                ", attributeValue='" + attributeValue + '\'' +
-                '}';
     }
 
 }

--- a/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionAttributeRepository.java
+++ b/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionAttributeRepository.java
@@ -2,10 +2,14 @@ package yjh.devtoon.promotion.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
-import java.util.Optional;
+import java.util.List;
 
-public interface PromotionAttributeRepository extends JpaRepository<PromotionAttributeEntity, Long> {
+public interface PromotionAttributeRepository extends JpaRepository<PromotionAttributeEntity,
+        Long> {
 
-    Optional<PromotionAttributeEntity> findByPromotionEntityId(Long promotionId);
+    /**
+     * 현재 적용 가능한 프로모션에 포함된 모든 프로모션 속성 조회
+     */
+    List<PromotionAttributeEntity> findByPromotionEntityId(Long promotionId);
 
 }

--- a/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionRepository.java
+++ b/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionRepository.java
@@ -15,12 +15,12 @@ public interface PromotionRepository extends JpaRepository<PromotionEntity, Long
      * 현재 활성화된 모든 프로모션을 리스트로 반환합니다.
      */
     @Query("SELECT p FROM PromotionEntity p WHERE p.startDate <= :now AND p.endDate >= :now")
-    List<PromotionEntity> activePromotions(@Param("now") LocalDateTime now);
+    List<PromotionEntity> findActivePromotions(@Param("now") LocalDateTime now);
 
     /**
      * 현재 활성화된 모든 프로모션을 페이지로 반환합니다.
      */
     @Query("SELECT p FROM PromotionEntity p WHERE p.startDate <= :now AND p.endDate >= :now")
-    Page<PromotionEntity> findActivePromotions(@Param("now") LocalDateTime now, Pageable pageable);
+    Page<PromotionEntity> activePromotions(@Param("now") LocalDateTime now, Pageable pageable);
 
 }

--- a/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
+++ b/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
@@ -3,8 +3,6 @@ package yjh.devtoon.promotion.presentation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,13 +11,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.promotion.application.PromotionService;
 import yjh.devtoon.promotion.domain.PromotionAttributeEntity;
 import yjh.devtoon.promotion.domain.PromotionEntity;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
 import yjh.devtoon.promotion.dto.response.PromotionSoftDeleteResponse;
+import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionAttributesResponse;
 import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionsResponse;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequestMapping("/v1/promotions")
@@ -33,11 +34,11 @@ public class PromotionController {
      * 프로모션 등록
      */
     @PostMapping
-    public ResponseEntity<ApiReponse> register(
+    public ResponseEntity<ApiResponse> register(
             @RequestBody @Valid final PromotionCreateRequest request
     ) {
         promotionService.register(request);
-        return ResponseEntity.ok(ApiReponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
@@ -45,35 +46,45 @@ public class PromotionController {
      * : 삭제 시간을 통해 로직상에서 삭제 처리를 구분합니다.
      */
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiReponse> delete(
+    public ResponseEntity<ApiResponse> delete(
             @PathVariable final Long id
     ) {
         PromotionEntity promotionEntity = promotionService.delete(id);
         PromotionSoftDeleteResponse response = PromotionSoftDeleteResponse.from(promotionEntity);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
-     * 현재 활성화된 프로모션 전체 조회
-     * : 현재 활성화된 프로모션이 없는 경우 빈 페이지를 반환합니다.
+     * 현재 적용 가능한 모든 프로모션 조회
+     * : 프로모션만 조회합니다. 현재 적용 가능한 모든 프로모션이 없는 경우 빈 리스트를 반환합니다.
      */
     @GetMapping("/now")
-    public ResponseEntity<ApiReponse<Page<RetrieveActivePromotionsResponse>>> retrieveActivePromotions(
-            final Pageable pageable
-    ) {
-        Page<PromotionEntity> activePromotions =
-                promotionService.retrieveActivePromotions(pageable);
+    public ResponseEntity<ApiResponse<List<RetrieveActivePromotionsResponse>>> retrieveActivePromotions() {
+        List<PromotionEntity> activePromotions = promotionService.retrieveActivePromotions();
+        List<RetrieveActivePromotionsResponse> response = activePromotions.stream()
+                .map(RetrieveActivePromotionsResponse::from)
+                .collect(Collectors.toList());
 
-        Page<RetrieveActivePromotionsResponse> response =
-                activePromotions.map(promotionEntity -> {
-                    PromotionAttributeEntity promotionAttribute =
-                            promotionService.validatePromotionAttributeExists(promotionEntity);
-                    return RetrieveActivePromotionsResponse.from(
-                            promotionEntity,
-                            promotionAttribute
-                    );
-                });
-        return ResponseEntity.ok(ApiReponse.success(response));
+
+        System.out.println(response.size());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 현재 적용 가능한 프로모션에 포함된 모든 프로모션 속성 조회
+     * : 현재 적용 가능한 프로모션이 없는 경우 빈 리스트를 반환합니다.
+     */
+    @GetMapping("/now/{id}")
+    public ResponseEntity<ApiResponse<List<RetrieveActivePromotionAttributesResponse>>> retrieveActivePromotionAttributes(
+            @PathVariable final Long id
+    ) {
+        List<PromotionAttributeEntity> activePromotionAttributes =
+                promotionService.retrieveActivePromotionAttributes(id);
+        List<RetrieveActivePromotionAttributesResponse> response =
+                activePromotionAttributes.stream()
+                        .map(RetrieveActivePromotionAttributesResponse::from)
+                        .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/yjh/devtoon/webtoon/presentation/WebtoonController.java
+++ b/src/main/java/yjh/devtoon/webtoon/presentation/WebtoonController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.webtoon.application.WebtoonService;
 import yjh.devtoon.webtoon.domain.WebtoonEntity;
 import yjh.devtoon.webtoon.dto.request.WebtoonCreateRequest;
@@ -26,23 +26,23 @@ public class WebtoonController {
      * 웹툰 등록
      */
     @PostMapping
-    public ResponseEntity<ApiReponse> registerWebtoon(
+    public ResponseEntity<ApiResponse> registerWebtoon(
             @RequestBody @Valid final WebtoonCreateRequest request
     ) {
         webtoonService.createWebtoon(request);
-        return ResponseEntity.ok(ApiReponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 웹툰 조회
      */
     @GetMapping("/{id}")
-    public ResponseEntity<ApiReponse> retrieve(
+    public ResponseEntity<ApiResponse> retrieve(
         @PathVariable final Long id
     ) {
         WebtoonEntity webtoon = webtoonService.retrieve(id);
         WebtoonResponse response = WebtoonResponse.from(webtoon);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/yjh/devtoon/webtoon_viewer/presentation/WebtoonViewerController.java
+++ b/src/main/java/yjh/devtoon/webtoon_viewer/presentation/WebtoonViewerController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import yjh.devtoon.common.response.ApiReponse;
+import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.webtoon_viewer.application.WebtoonViewerService;
 import yjh.devtoon.webtoon_viewer.domain.WebtoonViewerEntity;
 import yjh.devtoon.webtoon_viewer.dto.request.MembershipStatusChangeRequest;
@@ -28,35 +28,35 @@ public class WebtoonViewerController {
      * 웹툰 구독자 회원 등록
      */
     @PostMapping
-    public ResponseEntity<ApiReponse> register(
+    public ResponseEntity<ApiResponse> register(
             @RequestBody @Valid final WebtoonViewerRegisterRequest request
     ) {
         webtoonViewerService.register(request);
-        return ResponseEntity.ok(ApiReponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     /**
      * 웹툰 구독자 회원 조회
      */
     @GetMapping("/{id}")
-    public ResponseEntity<ApiReponse> retrieve(
+    public ResponseEntity<ApiResponse> retrieve(
             @PathVariable final Long id
     ) {
         WebtoonViewerEntity webtoonViewer = webtoonViewerService.retrieve(id);
         WebtoonViewerResponse response = WebtoonViewerResponse.from(webtoonViewer);
-        return ResponseEntity.ok(ApiReponse.success(response));
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     /**
      * 웹툰 구독자 회원 등급 변경
      */
     @PatchMapping("/{id}")
-    public ResponseEntity<ApiReponse> changeMembershipStatus(
+    public ResponseEntity<ApiResponse> changeMembershipStatus(
             @PathVariable final Long id,
             @RequestBody @Valid final MembershipStatusChangeRequest request
     ) {
         webtoonViewerService.changeMembershipStatus(id, request);
-        return ResponseEntity.ok(ApiReponse.success(null));
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 
 }

--- a/src/test/java/yjh/devtoon/promotion/integration/PromotionIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/promotion/integration/PromotionIntegrationTest.java
@@ -1,14 +1,19 @@
 package yjh.devtoon.promotion.integration;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static yjh.devtoon.promotion.domain.DiscountType.CASH_DISCOUNT;
+import static yjh.devtoon.promotion.domain.DiscountType.COOKIE_QUANTITY_DISCOUNT;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -56,7 +61,7 @@ public class PromotionIntegrationTest {
     class PromotionRegisterTests {
 
         private static final String DESCRIPTION = "7월 스릴러 장르 파격 할인 행사입니다.";
-        private static final DiscountType DISCOUNT_TYPE = DiscountType.COOKIE_QUANTITY_DISCOUNT;
+        private static final DiscountType DISCOUNT_TYPE = COOKIE_QUANTITY_DISCOUNT;
         private static final BigDecimal DISCOUNT_RATE = null;
         private static final Integer DISCOUNT_QUANTITY = 1;
         private static final Boolean IS_DISCOUNT_DUPLICATABLE = true;
@@ -171,7 +176,7 @@ public class PromotionIntegrationTest {
     class PromotionSoftDeleteTests {
 
         private static final String DESCRIPTION = "12월 로맨스 장르 파격 할인 행사입니다.";
-        private static final DiscountType DISCOUNT_TYPE = DiscountType.CASH_DISCOUNT;
+        private static final DiscountType DISCOUNT_TYPE = CASH_DISCOUNT;
         private static final BigDecimal DISCOUNT_RATE = BigDecimal.valueOf(10);
         private static final Integer DISCOUNT_QUANTITY = null;
         private static final Boolean IS_DISCOUNT_DUPLICATABLE = true;
@@ -243,146 +248,138 @@ public class PromotionIntegrationTest {
 
     }
 
-//    @Nested
-//    @DisplayName("프로모션 조회 테스트")
-//    class RetrieveActivePromotionsTests {
-//
-//        private static final List<PromotionAttributeCreateRequest> PROMOTION_ATTRIBUTES = List.of(
-//                new PromotionAttributeCreateRequest("target-month", "12"),
-//                new PromotionAttributeCreateRequest("target-genre", "romance")
-//        );
-//
-//        @DisplayName("현재 시간 기준 유효한 프로모션 전체 조회")
-//        @TestFactory
-//        Stream<DynamicTest> whenCurrentTimeGiven_thenListActivePromotionsPaged() {
-//            return Stream.of(
-//                    DynamicTest.dynamicTest("1. 프로모션1 저장 ->", () -> {
-//                        // given
-//                        PromotionEntity promotion1 = PromotionEntity.create(
-//                                "12월 로맨스 장르 파격 할인 행사입니다.",
-//                                DiscountType.CASH_DISCOUNT,
-//                                BigDecimal.valueOf(10),
-//                                null,
-//                                true,
-//                                LocalDateTime.of(2024, 12, 1, 0, 0, 0),
-//                                LocalDateTime.of(2024, 12, 31, 11, 59, 59)
-//                        );
-//                        PromotionEntity savedPromotion1 = promotionRepository.save(promotion1);
-//
-//                        PROMOTION_ATTRIBUTES.stream()
-//                                .map(promotionAttributeRequest -> PromotionAttributeEntity.create(
-//                                        savedPromotion1,
-//                                        promotionAttributeRequest.getAttributeName(),
-//                                        promotionAttributeRequest.getAttributeValue()
-//                                ))
-//                                .forEach(promotionAttributeRepository::save);
-//
-//                    }), DynamicTest.dynamicTest("2. 프로모션2 저장 ->", () -> {
-//                        // given
-//                        PromotionEntity promotion2 = PromotionEntity.create(
-//                                "7월 장르 파격 할인 행사입니다.",
-//                                DiscountType.COOKIE_QUANTITY_DISCOUNT,
-//                                null,
-//                                2,
-//                                true,
-//                                LocalDateTime.of(2024, 7, 1, 0, 0, 0),
-//                                LocalDateTime.of(2024, 7, 31, 11, 59, 59)
-//                        );
-//                        PromotionEntity savedPromotion2 = promotionRepository.save(promotion2);
-//
-//                        PROMOTION_ATTRIBUTES.stream()
-//                                .map(promotionAttributeRequest -> PromotionAttributeEntity.create(
-//                                        savedPromotion2,
-//                                        promotionAttributeRequest.getAttributeName(),
-//                                        promotionAttributeRequest.getAttributeValue()
-//                                ))
-//                                .forEach(promotionAttributeRepository::save);
-//
-//                    }), DynamicTest.dynamicTest("3. 유효한 프로모션 조회", () -> {
-//                        // when, then
-//                        mockMvc.perform(get("/v1/promotions/now")
-//                                        .contentType(MediaType.APPLICATION_JSON))
-//                                .andExpect(status().isOk())
-//                                .andExpect(jsonPath("$.statusMessage").value("성공"))
-//                                .andExpect(jsonPath("$.data.content[0].description").value("12월
-//                                로맨스 장르 파격 할인 행사입니다."))
-//                                .andExpect(jsonPath("$.data.content[0].startDate").value
-//                                ("2024-05" +
-//                                        "-13T23:44:00"))
-//                                .andExpect(jsonPath("$.data.content[0].endDate").value("2024-07" +
-//                                        "-01T00:00:00"))
-//                                .andExpect(jsonPath("$.data.content[0].attributeName").value(
-//                                        "target-month"))
-//                                .andExpect(jsonPath("$.data.content[0].attributeValue").value
-//                                ("6"))
-//                                .andExpect(jsonPath("$.data.content[1].description").value("스릴러
-//                                " +
-//                                        "프로모션"))
-//                                .andExpect(jsonPath("$.data.content[1].startDate").value
-//                                ("2024-05" +
-//                                        "-13T23:44:00"))
-//                                .andExpect(jsonPath("$.data.content[1].endDate").value("2024-07" +
-//                                        "-01T00:00:00"))
-//                                .andExpect(jsonPath("$.data.content[1].attributeName").value(
-//                                        "target-genre"))
-//                                .andExpect(jsonPath("$.data.content[1].attributeValue").value(
-//                                        "thriller"));
-//                    })
-//            );
-//        }
-//
-//        @DisplayName("현재 시간 기준 유효한 프로모션 조회 - 등록된 프로모션이 현재 시간에는 유효하지 않을 경우 빈 페이지 반환")
-//        @TestFactory
-//        Stream<DynamicTest> whenCurrentTimeGiven_AndNoPromotions_thenReturnEmptyPage() throws
-//        Exception {
-//            return Stream.of(
-//                    DynamicTest.dynamicTest("1. 과거 프로모션1 저장 ->", () -> {
-//                        // given
-//                        PromotionEntity promotionEntity = PromotionEntity.builder()
-//                                .description("여름 프로모션")
-//                                .startDate(LocalDateTime.of(2024, 1, 1, 0, 0, 0))
-//                                .endDate(LocalDateTime.of(2024, 5, 1, 0, 0, 0))
-//                                .build();
-//                        PromotionEntity savedPromotion1 = promotionRepository.save
-//                        (promotionEntity);
-//
-//                        PromotionAttributeEntity promotionAttributeEntity =
-//                                PromotionAttributeEntity.builder()
-//                                .promotionEntity(savedPromotion1)
-//                                .attributeName("target-month")
-//                                .attributeValue("6")
-//                                .build();
-//                        promotionAttributeRepository.save(promotionAttributeEntity);
-//
-//                    }), DynamicTest.dynamicTest("2. 과거 프로모션2 저장 ->", () -> {
-//                        // given
-//                        PromotionEntity promotionEntity = PromotionEntity.builder()
-//                                .description("스릴러 프로모션")
-//                                .startDate(LocalDateTime.of(2024, 2, 1, 0, 0, 0))
-//                                .endDate(LocalDateTime.of(2024, 5, 1, 0, 0, 0))
-//                                .build();
-//                        PromotionEntity savedPromotion2 = promotionRepository.save
-//                        (promotionEntity);
-//
-//                        PromotionAttributeEntity promotionAttributeEntity =
-//                                PromotionAttributeEntity.builder()
-//                                .promotionEntity(savedPromotion2)
-//                                .attributeName("target-genre")
-//                                .attributeValue("thriller")
-//                                .build();
-//                        promotionAttributeRepository.save(promotionAttributeEntity);
-//
-//                    }), DynamicTest.dynamicTest("3. 유효한 프로모션 조회", () -> {
-//                        // when, then
-//                        mockMvc.perform(get("/v1/promotions/now")
-//                                        .contentType(MediaType.APPLICATION_JSON))
-//                                .andExpect(status().isOk())
-//                                .andExpect(jsonPath("$.statusMessage").value("성공"))
-//                                .andExpect(jsonPath("$.data.content").isEmpty());
-//                    })
-//            );
-//        }
-//
-//    }
+    @Nested
+    @DisplayName("프로모션 조회 테스트")
+    class RetrieveActivePromotionsTests {
+
+        private static final List<PromotionAttributeCreateRequest> PROMOTION_ATTRIBUTES = List.of(
+                new PromotionAttributeCreateRequest("target-month", "12"),
+                new PromotionAttributeCreateRequest("target-genre", "romance")
+        );
+
+        @DisplayName("현재 적용 가능한 모든 프로모션 조회")
+        @TestFactory
+        Stream<DynamicTest> whenCurrentTimeGiven_thenReturnActivePromotionsList() {
+            return Stream.of(
+                    DynamicTest.dynamicTest("1. 프로모션1 저장 ->", () -> {
+                        // given
+                        PromotionEntity promotion1 = PromotionEntity.create(
+                                "12월 로맨스 장르 파격 할인 행사입니다.",
+                                CASH_DISCOUNT,
+                                BigDecimal.valueOf(20),
+                                null,
+                                true,
+                                LocalDateTime.now().minusMonths(1),
+                                LocalDateTime.now().plusMonths(1)
+                        );
+                        PromotionEntity savedPromotion1 = promotionRepository.save(promotion1);
+
+                        PROMOTION_ATTRIBUTES.stream()
+                                .map(promotionAttributeRequest -> PromotionAttributeEntity.create(
+                                        savedPromotion1,
+                                        promotionAttributeRequest.getAttributeName(),
+                                        promotionAttributeRequest.getAttributeValue()
+                                ))
+                                .forEach(promotionAttributeRepository::save);
+
+                    }), DynamicTest.dynamicTest("2. 프로모션2 저장 ->", () -> {
+                        // given
+                        PromotionEntity promotion2 = PromotionEntity.create(
+                                "7월 로맨스 장르 파격 할인 행사입니다.",
+                                COOKIE_QUANTITY_DISCOUNT,
+                                null,
+                                2,
+                                true,
+                                LocalDateTime.now().minusMonths(1),
+                                LocalDateTime.now().plusMonths(1)
+                        );
+                        PromotionEntity savedPromotion2 = promotionRepository.save(promotion2);
+
+                        PROMOTION_ATTRIBUTES.stream()
+                                .map(promotionAttributeRequest -> PromotionAttributeEntity.create(
+                                        savedPromotion2,
+                                        promotionAttributeRequest.getAttributeName(),
+                                        promotionAttributeRequest.getAttributeValue()
+                                ))
+                                .forEach(promotionAttributeRepository::save);
+
+                    }), DynamicTest.dynamicTest("3. 현재 적용 가능한 모든 프로모션 조회", () -> {
+
+                        // when, then
+                        mockMvc.perform(get("/v1/promotions/now")
+                                        .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.statusMessage").value("성공"))
+                                .andExpect(jsonPath("$.data[0].description").value("12월 로맨스 장르 파격" +
+                                        " 할인 행사입니다."))
+                                .andExpect(jsonPath("$.data[0].discountType").value(
+                                        "CASH_DISCOUNT"))
+                                .andExpect(jsonPath("$.data[1].description").value("7월 로맨스 장르 파격 " +
+                                        "할인 행사입니다."))
+                                .andExpect(jsonPath("$.data[1].discountType").value(
+                                        "COOKIE_QUANTITY_DISCOUNT"));
+                    })
+            );
+        }
+
+        @DisplayName("현재 적용 가능한 모든 프로모션 조회 - 해당 프로모션이 없는 경우 빈 리스트를 반환")
+        @TestFactory
+        Stream<DynamicTest> whenCurrentTimeGiven_AndNoPromotions_thenReturnEmptyList() throws
+                Exception {
+            return Stream.of(
+                    DynamicTest.dynamicTest("1. 과거 프로모션1 저장 ->", () -> {
+                        // given
+                        PromotionEntity promotion1 = PromotionEntity.create(
+                                "12월 로맨스 장르 파격 할인 행사입니다.",
+                                CASH_DISCOUNT,
+                                BigDecimal.valueOf(20),
+                                null,
+                                true,
+                                LocalDateTime.now().minusMonths(2),
+                                LocalDateTime.now().minusMonths(1)
+                        );
+                        PromotionEntity savedPromotion1 = promotionRepository.save(promotion1);
+
+                        PROMOTION_ATTRIBUTES.stream()
+                                .map(promotionAttributeRequest -> PromotionAttributeEntity.create(
+                                        savedPromotion1,
+                                        promotionAttributeRequest.getAttributeName(),
+                                        promotionAttributeRequest.getAttributeValue()
+                                ))
+                                .forEach(promotionAttributeRepository::save);
+
+                    }), DynamicTest.dynamicTest("2. 과거 프로모션2 저장 ->", () -> {
+                        // given
+                        PromotionEntity promotion2 = PromotionEntity.create(
+                                "7월 로맨스 장르 파격 할인 행사입니다.",
+                                COOKIE_QUANTITY_DISCOUNT,
+                                null,
+                                2,
+                                true,
+                                LocalDateTime.now().minusMonths(2),
+                                LocalDateTime.now().minusMonths(1)
+                        );
+                        PromotionEntity savedPromotion2 = promotionRepository.save(promotion2);
+
+                        PROMOTION_ATTRIBUTES.stream()
+                                .map(promotionAttributeRequest -> PromotionAttributeEntity.create(
+                                        savedPromotion2,
+                                        promotionAttributeRequest.getAttributeName(),
+                                        promotionAttributeRequest.getAttributeValue()
+                                ))
+                                .forEach(promotionAttributeRepository::save);
+
+                    }), DynamicTest.dynamicTest("3. 유효한 프로모션 조회", () -> {
+                        // when, then
+                        mockMvc.perform(get("/v1/promotions/now")
+                                        .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.statusMessage").value("성공"))
+                                .andExpect(jsonPath("$.data[*]").isEmpty());
+                    })
+            );
+        }
+
+    }
 
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 프로모션 조회 로직 수정 및 통합 테스트

## 💡️ 이슈
- 기존 프로모션 조회의 경우 특정 프로모션에 속한 하나의 속성만 출력되는 문제가 있었습니다. 이에 api를 2개로 분리하고 프로모션만 조회, 프로모션 내 속성이 궁금하다면 프로모션 아이디를 통해 속성들 리스트를 반환해서 조회하도록 해결했습니다.

## 📢 논의하고 싶은 내용