### PR TITLE
refactor: 프로모션 조회에 Redis 캐시 적용 및 성능 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/src/main/java/yjh/devtoon/common/config/RedisConfig.java
+++ b/src/main/java/yjh/devtoon/common/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package yjh.devtoon.common.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import yjh.devtoon.promotion.domain.PromotionEntity;
+import java.util.List;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, List<PromotionEntity>> promotionRedisTemplate(RedisConnectionFactory connectionFactory) {
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .registerModule(new JavaTimeModule())
+                .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisTemplate<String, List<PromotionEntity>> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        return template;
+    }
+
+}

--- a/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
+++ b/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
@@ -25,11 +25,12 @@ import java.util.List;
 @Service
 public class PromotionService {
 
+    private static final String CACHE_KEY = "promotion:active:list";
+    private static final Duration CACHE_DURATION = Duration.ofHours(24);
+
     private final PromotionRepository promotionRepository;
     private final PromotionAttributeRepository promotionAttributeRepository;
     private final RedisTemplate<String, List<PromotionEntity>> promotionRedisTemplate;
-    private static final String CACHE_KEY = "promotion:active:list";
-    private static final Duration CACHE_DURATION = Duration.ofHours(24);
 
     /**
      * 프로모션 등록

--- a/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
+++ b/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
@@ -2,7 +2,7 @@ package yjh.devtoon.promotion.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yjh.devtoon.common.exception.DevtoonException;
@@ -15,6 +15,7 @@ import yjh.devtoon.promotion.dto.request.PromotionAttributeCreateRequest;
 import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
 import yjh.devtoon.promotion.infrastructure.PromotionAttributeRepository;
 import yjh.devtoon.promotion.infrastructure.PromotionRepository;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -26,7 +27,9 @@ public class PromotionService {
 
     private final PromotionRepository promotionRepository;
     private final PromotionAttributeRepository promotionAttributeRepository;
-    private final PromotionCacheService promotionCacheService;
+    private final RedisTemplate<String, List<PromotionEntity>> promotionRedisTemplate;
+    private static final String CACHE_KEY = "promotion:active:list";
+    private static final Duration CACHE_DURATION = Duration.ofHours(24);
 
     /**
      * 프로모션 등록
@@ -51,8 +54,6 @@ public class PromotionService {
                 .map(promotionAttributeRequest -> toEntity(savedPromotion,
                         promotionAttributeRequest))
                 .forEach(promotionAttributeRepository::save);
-
-        promotionCacheService.updatePromotionInCache(savedPromotion);
     }
 
     private PromotionAttributeEntity toEntity(
@@ -77,7 +78,6 @@ public class PromotionService {
                         ErrorMessage.getResourceNotFound(ResourceType.PROMOTION, id)
                 ));
         promotion.recordDeletion(LocalDateTime.now());
-        promotionCacheService.evictPromotionFromCache(id);
         return promotionRepository.save(promotion);
     }
 
@@ -86,14 +86,33 @@ public class PromotionService {
      * : 프로모션만 조회합니다. 프로모션이 없는 경우 빈 리스트를 반환합니다.
      */
     @Transactional(readOnly = true)
-    @Cacheable(value = "promotion", key = "'active'")
     public List<PromotionEntity> retrieveActivePromotions() {
-        List<PromotionEntity> promotions = retrieveCurrentOrFuturePromotion();
+        List<PromotionEntity> promotions = getCachedPromotions();
+        if (promotions == null) {
+            promotions = fetchAndCachePromotions();
+        }
+        return promotions;
+    }
 
-        List<PromotionEntity> currentPromotions =
-                filterCurrentPromotions(promotions);
-        currentPromotions.forEach(promotion -> log.info("프로모션: {}", promotion));
-        return currentPromotions;
+    /**
+     * 캐시에서 프로모션 조회
+     */
+    private List<PromotionEntity> getCachedPromotions() {
+        List<PromotionEntity> cachedPromotions =
+                promotionRedisTemplate.opsForValue().get(CACHE_KEY);
+        if (cachedPromotions != null) {
+            return filterCurrentPromotions(cachedPromotions);
+        }
+        return null;
+    }
+
+    /**
+     * DB에서 프로모션 조회 후 캐시에 저장
+     */
+    private List<PromotionEntity> fetchAndCachePromotions() {
+        List<PromotionEntity> promotions = retrieveCurrentOrFuturePromotion();
+        promotionRedisTemplate.opsForValue().set(CACHE_KEY, promotions, CACHE_DURATION);
+        return filterCurrentPromotions(promotions);
     }
 
     private List<PromotionEntity> retrieveCurrentOrFuturePromotion() {
@@ -105,13 +124,6 @@ public class PromotionService {
             return Collections.emptyList();
         }
         return promotions;
-    }
-
-    private List<PromotionEntity> filterCurrentOrFuturePromotions(final List<PromotionEntity> promotions) {
-        LocalDateTime currentTime = LocalDateTime.now();
-        return promotions.stream()
-                .filter(p -> p.isCurrentOrFuture(currentTime))
-                .toList();
     }
 
     private List<PromotionEntity> filterCurrentPromotions(final List<PromotionEntity> currentAndFuturePromotions) {

--- a/src/main/java/yjh/devtoon/promotion/presentation/PromotionCacheController.java
+++ b/src/main/java/yjh/devtoon/promotion/presentation/PromotionCacheController.java
@@ -25,7 +25,7 @@ public class PromotionCacheController {
 
     /**
      * 임시 API
-     * : 프로모션 등록, 조회 API 요청시 캐시에 데이터가 잘 들어갔는지 확인하는 메서드.
+     * : 로컬 캐시 사용시 프로모션 등록, 조회 API 요청시 캐시에 데이터가 잘 들어갔는지 확인하는 메서드.
      */
     @GetMapping("/now/cache-details")
     public ResponseEntity<ApiResponse<List<Map<String, List<String>>>>> getPromotionCacheData() {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -4,6 +4,10 @@ spring:
     config:
         activate:
             on-profile: dev
+    data:
+        redis:
+            host: ${DEV_REDIS_HOST}
+            port: ${DEV_REDIS_PORT}
     datasource:
         url: jdbc:mysql://${DEV_MYSQL_URL}
         username: ${DEV_MYSQL_USER}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -45,17 +45,20 @@ WHERE NOT EXISTS (SELECT 1 FROM promotion WHERE description = '프로모션 3');
 
 -- 프로모션 4
 INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable, start_date, end_date, created_at, updated_at)
-SELECT '프로모션 4', 'COOKIE_QUANTITY_DISCOUNT', 10, TRUE, '2024-05-01 00:00:00', '2024-06-01 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+SELECT '프로모션 4', 'COOKIE_QUANTITY_DISCOUNT', 10, TRUE, '2024-06-01 00:00:00', '2024-06-29
+00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT 1 FROM promotion WHERE description = '프로모션 4');
 
 -- 프로모션 5
 INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable, start_date, end_date, created_at, updated_at)
-SELECT '프로모션 5', 'COOKIE_QUANTITY_DISCOUNT', 5, FALSE, '2024-05-15 00:00:00', '2024-06-15 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+SELECT '프로모션 5', 'COOKIE_QUANTITY_DISCOUNT', 5, FALSE, '2024-06-02 00:00:00', '2024-06-30
+00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT 1 FROM promotion WHERE description = '프로모션 5');
 
 -- 프로모션 6
 INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable, start_date, end_date, created_at, updated_at)
-SELECT '프로모션 6', 'COOKIE_QUANTITY_DISCOUNT', 7, TRUE, '2024-05-01 00:00:00', '2024-06-01 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+SELECT '프로모션 6', 'COOKIE_QUANTITY_DISCOUNT', 7, TRUE, '2024-05-01 00:00:00', '2024-06-28
+00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT 1 FROM promotion WHERE description = '프로모션 6');
 
 -- 프로모션 7 (미래 프로모션)

--- a/src/test/java/yjh/devtoon/promotion/application/PromotionServiceTest.java
+++ b/src/test/java/yjh/devtoon/promotion/application/PromotionServiceTest.java
@@ -94,7 +94,6 @@ class PromotionServiceTest {
 
             // then
             verify(promotionRepository, times(1)).save(any(PromotionEntity.class));
-            verify(promotionCacheService, times(1)).updatePromotionInCache(promotionEntityCaptor.capture());
         }
     }
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 프로모션 조회에 Spring Boot Redis 캐시 적용 (캐시 유효 기간: 24시간 설정)

## 💡️ 이슈
- 유저 수: 3000명
- ramp up: 300명
- 처리 시간: 1분
- 평균 응답 시간: 2.2초 (로컬 캐시 Caffeine의 평균 응답 시간은 0.14초)

로컬 캐시인 Caffeine과 Spring Boot Redis를 비교한 결과, 네트워크 오버헤드가 없는 Caffeine이 더 우수했습니다. 현재 모놀리스 아키텍처를 적용하고 있으며, 애플리케이션 요구사항상 프로모션이 대량으로 등록될 일이 없으므로 Caffeine이 더 적합하다고 판단했습니다. 추후 MSA를 적용할 경우, 데이터 일관성 유지와 다양한 자료구조를 지원하는 Redis를 고려해보는 것도 좋을 것 같습니다. 😀

## 📢 논의하고 싶은 내용