### PR TITLE
refactor: 프로모션 조회에 로컬 캐시 사용으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/src/main/java/yjh/devtoon/common/config/RedisConfig.java
+++ b/src/main/java/yjh/devtoon/common/config/RedisConfig.java
@@ -1,44 +1,44 @@
-package yjh.devtoon.common.config;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-import yjh.devtoon.promotion.domain.PromotionEntity;
-import java.util.List;
-
-@Configuration
-public class RedisConfig {
-
-    @Bean
-    public RedisTemplate<String, List<PromotionEntity>> promotionRedisTemplate(RedisConnectionFactory connectionFactory) {
-        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
-                .builder()
-                .allowIfSubType(Object.class)
-                .build();
-
-        ObjectMapper objectMapper = new ObjectMapper()
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .registerModule(new JavaTimeModule())
-                .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL)
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-        GenericJackson2JsonRedisSerializer serializer =
-                new GenericJackson2JsonRedisSerializer(objectMapper);
-
-        RedisTemplate<String, List<PromotionEntity>> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(serializer);
-        return template;
-    }
-
-}
+//package yjh.devtoon.common.config;
+//
+//import com.fasterxml.jackson.databind.DeserializationFeature;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.fasterxml.jackson.databind.SerializationFeature;
+//import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+//import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+//import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.redis.connection.RedisConnectionFactory;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+//import org.springframework.data.redis.serializer.StringRedisSerializer;
+//import yjh.devtoon.promotion.domain.PromotionEntity;
+//import java.util.List;
+//
+//@Configuration
+//public class RedisConfig {
+//
+//    @Bean
+//    public RedisTemplate<String, List<PromotionEntity>> promotionRedisTemplate(RedisConnectionFactory connectionFactory) {
+//        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
+//                .builder()
+//                .allowIfSubType(Object.class)
+//                .build();
+//
+//        ObjectMapper objectMapper = new ObjectMapper()
+//                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+//                .registerModule(new JavaTimeModule())
+//                .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL)
+//                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+//
+//        GenericJackson2JsonRedisSerializer serializer =
+//                new GenericJackson2JsonRedisSerializer(objectMapper);
+//
+//        RedisTemplate<String, List<PromotionEntity>> template = new RedisTemplate<>();
+//        template.setConnectionFactory(connectionFactory);
+//        template.setKeySerializer(new StringRedisSerializer());
+//        template.setValueSerializer(serializer);
+//        return template;
+//    }
+//
+//}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -4,10 +4,10 @@ spring:
     config:
         activate:
             on-profile: dev
-    data:
-        redis:
-            host: ${DEV_REDIS_HOST}
-            port: ${DEV_REDIS_PORT}
+#    data:
+#        redis:
+#            host: ${DEV_REDIS_HOST}
+#            port: ${DEV_REDIS_PORT}
     datasource:
         url: jdbc:mysql://${DEV_MYSQL_URL}
         username: ${DEV_MYSQL_USER}

--- a/src/test/java/yjh/devtoon/payment/integration/CookiePaymentIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/payment/integration/CookiePaymentIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import yjh.devtoon.cookie_wallet.domain.CookieWalletEntity;
@@ -35,6 +36,7 @@ import java.time.LocalDateTime;
 @DisplayName("통합 테스트 [CookiePaymentIntegration]")
 @Transactional
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class CookiePaymentIntegrationTest {
 
@@ -92,11 +94,10 @@ public class CookiePaymentIntegrationTest {
             PromotionEntity savedPromotion = promotionRepository.save(PromotionEntity.builder()
                     .id(1L)
                     .description("12월 로맨스 프로모션입니다.")
-                    .discountType(DiscountType.CASH_DISCOUNT)
-                    .discountRate(BigDecimal.valueOf(10))
+                    .discountType(DiscountType.COOKIE_QUANTITY_DISCOUNT)
+                    .discountQuantity(2)
                     .isDiscountDuplicatable(true)
                     .startDate(LocalDateTime.parse("2024-05-01T00:00"))
-                    .endDate(LocalDateTime.parse("2024-12-29T00:00"))
                     .build());
 
             // 4. cookie wallet 저장
@@ -158,7 +159,6 @@ public class CookiePaymentIntegrationTest {
                     .andExpect(jsonPath("$.data.totalPrice").value(1000))
                     .andExpect(jsonPath("$.data.totalDiscountRate").value(0.1))
                     .andExpect(jsonPath("$.data.paymentPrice").value(900));
-
         }
 
     }

--- a/src/test/java/yjh/devtoon/payment/integration/WebtoonPaymentIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/payment/integration/WebtoonPaymentIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import yjh.devtoon.cookie_wallet.domain.CookieWalletEntity;
@@ -40,6 +41,7 @@ import java.time.LocalDateTime;
 @DisplayName("통합 테스트 [WebtoonPaymentIntegration]")
 @Transactional
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class WebtoonPaymentIntegrationTest {
 
@@ -111,15 +113,22 @@ public class WebtoonPaymentIntegrationTest {
                     .discountType(COOKIE_QUANTITY_DISCOUNT)
                     .discountQuantity(1)
                     .startDate(LocalDateTime.parse("2024-06-01T00:00:00"))
-                    .endDate(LocalDateTime.parse("2024-08-31T23:59:59"))
                     .build());
 
-            PromotionAttributeEntity savedPromotionAttribute =
+            // 4-1. promotion attributes 등록
+            PromotionAttributeEntity savedPromotionAttribute1 =
                     promotionAttributeRepository.save(PromotionAttributeEntity.builder()
-                    .promotionEntity(savedPromotion)
-                    .attributeName("target_author")
-                    .attributeValue("오성대")
-                    .build());
+                            .promotionEntity(savedPromotion)
+                            .attributeName("target_author")
+                            .attributeValue("오성대")
+                            .build());
+
+            PromotionAttributeEntity savedPromotionAttribute2 =
+                    promotionAttributeRepository.save(PromotionAttributeEntity.builder()
+                            .promotionEntity(savedPromotion)
+                            .attributeName("target_genre")
+                            .attributeValue(Genre.HORROR.getName())
+                            .build());
 
             // 5. cookieWallet 등록
             CookieWalletEntity savedCookieWallet =
@@ -183,7 +192,6 @@ public class WebtoonPaymentIntegrationTest {
                     .andExpect(jsonPath("$.data.webtoonNo").value(3L))
                     .andExpect(jsonPath("$.data.webtoonDetailNo").value(10L))
                     .andExpect(jsonPath("$.data.cookiePaymentAmount").value(3L));
-
         }
 
     }


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 프로모션 조회에 Caffeine 로컬 캐시 사용으로 변경
- [x] 웹툰 미리보기 결제 통합 테스트 에러 해결

## 💡️ 이슈
- 프로모션 조회 시 최종적으로 Caffeine 로컬 캐시를 적용하기로 결정하여 해당 로직으로 변경했습니다.
- 문제 발생
  - @ Transactional 롤백이 제대로 작동하지 않는 문제가 발생했습니다. 
- 문제 발생 지점
  - [쿠키 결제 통합 테스트]에서 등록한 프로모션이 [웹툰 결제 통합 테스트] 프로모션 등록 로직에 재사용되었습니다.
- 문제 원인
  - Spring 테스트 프레임워크는 테스트의 성능을 향상시키기 위해 애플리케이션 컨텍스트를 캐시합니다. 동일한 애플리케이션 컨텍스트 구성을 사용하는 테스트는 재사용됩니다.
- 원인 분석
  - 두 테스트 클래스가 동일한 컨텍스트를 공유하고, 데이터베이스를 사용하여 데이터를 변경한다면, 첫 번째 테스트 클래스에서의 데이터 변경이 두 번째 테스트 클래스에 영향을 미칠 수 있습니다.
- 문제 해결 
  - @DirtiesContext 애너테이션을 사용하여 각 테스트가 끝난 후 애플리케이션 컨텍스트를 다시 로드하도록 강제하여 해결했습니다. 그러나 이 방법은 성능 이슈를 야기할 수 있습니다.
  - 성능 이슈를 최소화하기 위해 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)를 설정하여 각 테스트 클래스가 끝난 후에만 컨텍스트를 다시 로드하도록 했습니다. 

## 📢 논의하고 싶은 내용