### PR TITLE
feat: 웹툰 전체 조회 기능 구현

### DIFF
--- a/src/main/java/yjh/devtoon/webtoon/application/WebtoonService.java
+++ b/src/main/java/yjh/devtoon/webtoon/application/WebtoonService.java
@@ -1,6 +1,8 @@
 package yjh.devtoon.webtoon.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yjh.devtoon.common.exception.DevtoonException;
@@ -45,4 +47,7 @@ public class WebtoonService {
                 });
     }
 
+    public Page<WebtoonEntity> retrieveAll(Pageable pageable) {
+        return webtoonRepository.findAll(pageable);
+    }
 }

--- a/src/main/java/yjh/devtoon/webtoon/presentation/WebtoonController.java
+++ b/src/main/java/yjh/devtoon/webtoon/presentation/WebtoonController.java
@@ -2,6 +2,8 @@ package yjh.devtoon.webtoon.presentation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -43,6 +45,16 @@ public class WebtoonController {
         WebtoonEntity webtoon = webtoonService.retrieve(id);
         WebtoonResponse response = WebtoonResponse.from(webtoon);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 웹툰 전체 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse> retrieveAll(Pageable pageable) {
+        Page<WebtoonEntity> webtoons = webtoonService.retrieveAll(pageable);
+        Page<WebtoonResponse> webtoonsResponse = webtoons.map(WebtoonResponse::from);
+        return ResponseEntity.ok(ApiResponse.success(webtoonsResponse));
     }
 
 }

--- a/src/test/java/yjh/devtoon/webtoon/integration/WebtoonIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/webtoon/integration/WebtoonIntegrationTest.java
@@ -211,4 +211,37 @@ public class WebtoonIntegrationTest {
 
     }
 
+    @Nested
+    @DisplayName("웹툰 전체 조회 테스트")
+    class WebtoonRetrieveAllTests {
+
+        @DisplayName("웹툰 전체 조회 성공")
+        @Test
+        void retrieveAllWebtoon_successfully() throws Exception {
+            // given
+            WebtoonEntity webtoonEntity1 = WebtoonEntity.builder()
+                    .title("쿠베라")
+                    .writerName("카레곰")
+                    .genre(Genre.HORROR)
+                    .build();
+            webtoonRepository.save(webtoonEntity1);
+
+            WebtoonEntity webtoonEntity2 = WebtoonEntity.builder()
+                    .title("기기괴괴")
+                    .writerName("오성대")
+                    .genre(Genre.HORROR)
+                    .build();
+            webtoonRepository.save(webtoonEntity2);
+
+            // when
+            mockMvc.perform(get("/v1/webtoons")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.statusMessage").value("성공"))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content[0].title").value("쿠베라"))
+                    .andExpect(jsonPath("$.data.content[1].title").value("기기괴괴"));
+        }
+    }
+
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 웹툰 전체 조회 기능 구현

## 💡️ 이슈
- x

## 📢 논의하고 싶은 내용
- 페이지 단위로 불러오도록 구현하였습니다. 현재 WebtoonEntity를 Page의 map 메서드를 통해서 WebtoonResponse로 변환하고 있는데요, 이 부분 나중에 성능상 좋지 않다고 판단되면 Entity에서 Reponse로 변환하는게 아니라 곧바로 Response형태로 맵핑하는 방식을 고려해봐도 좋을 것 같아요!(아직 나중 이야기지만!)