### PR TITLE
feat: 비속어 정책 조회 API구현 

### DIFF
--- a/src/main/java/yjh/devtoon/policy/application/PolicyService.java
+++ b/src/main/java/yjh/devtoon/policy/application/PolicyService.java
@@ -10,10 +10,12 @@ import yjh.devtoon.common.exception.ErrorCode;
 import yjh.devtoon.common.utils.ResourceType;
 import yjh.devtoon.policy.common.Policy;
 import yjh.devtoon.policy.constant.ErrorMessage;
+import yjh.devtoon.policy.domain.BadWordsPolicyEntity;
 import yjh.devtoon.policy.domain.CookiePolicyEntity;
 import yjh.devtoon.policy.domain.PolicyFactory;
 import yjh.devtoon.policy.domain.PolicyType;
 import yjh.devtoon.policy.dto.request.PolicyCreateRequest;
+import yjh.devtoon.policy.infrastructure.BadWordsPolicyRepository;
 import yjh.devtoon.policy.infrastructure.CookiePolicyRepository;
 import yjh.devtoon.policy.infrastructure.PolicyRepositoryRegistry;
 import java.util.Optional;
@@ -25,6 +27,7 @@ public class PolicyService {
 
     private final PolicyRepositoryRegistry policyRepositoryRegistry;
     private final CookiePolicyRepository cookiePolicyRepository;
+    private final BadWordsPolicyRepository badWordsPolicyRepository;
 
     /**
      * 정책 등록
@@ -63,6 +66,21 @@ public class PolicyService {
                         ErrorMessage.getResourceNotFound(
                                 ResourceType.POLICY,
                                 cookiePolicyRepository.findActiveCookiePolicy()
+                        )
+                ));
+    }
+
+    /**
+     * 비속어 정책 조회
+     */
+    @Transactional(readOnly = true)
+    public BadWordsPolicyEntity retrieveBadWordsPolicyPolicy() {
+        return badWordsPolicyRepository.findActiveBadWordsPolicy()
+                .orElseThrow(() -> new DevtoonException(
+                        ErrorCode.NOT_FOUND,
+                        ErrorMessage.getResourceNotFound(
+                                ResourceType.POLICY,
+                                badWordsPolicyRepository.findActiveBadWordsPolicy()
                         )
                 ));
     }

--- a/src/main/java/yjh/devtoon/policy/dto/response/RetrieveBadWordsPolicyResponse.java
+++ b/src/main/java/yjh/devtoon/policy/dto/response/RetrieveBadWordsPolicyResponse.java
@@ -1,0 +1,42 @@
+package yjh.devtoon.policy.dto.response;
+
+import lombok.Getter;
+import yjh.devtoon.policy.domain.BadWordsPolicyEntity;
+import java.time.LocalDateTime;
+
+@Getter
+public class RetrieveBadWordsPolicyResponse {
+
+    private int warningThreshold;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    protected LocalDateTime createdAt;
+    protected LocalDateTime updatedAt;
+
+    public RetrieveBadWordsPolicyResponse(
+            int warningThreshold,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.warningThreshold = warningThreshold;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static RetrieveBadWordsPolicyResponse from(
+            final BadWordsPolicyEntity badWordsPolicyEntity
+    ) {
+        return new RetrieveBadWordsPolicyResponse(
+                badWordsPolicyEntity.getWarningThreshold(),
+                badWordsPolicyEntity.getStartDate(),
+                badWordsPolicyEntity.getEndDate(),
+                badWordsPolicyEntity.getCreatedAt(),
+                badWordsPolicyEntity.getUpdatedAt()
+        );
+    }
+
+}

--- a/src/main/java/yjh/devtoon/policy/infrastructure/BadWordsPolicyRepository.java
+++ b/src/main/java/yjh/devtoon/policy/infrastructure/BadWordsPolicyRepository.java
@@ -1,7 +1,16 @@
 package yjh.devtoon.policy.infrastructure;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import yjh.devtoon.policy.domain.BadWordsPolicyEntity;
+import java.util.Optional;
 
 public interface BadWordsPolicyRepository extends JpaRepository<BadWordsPolicyEntity, Long> {
+
+    /**
+     * 현재 적용되는 BadWordsPolicy 조회합니다.
+     */
+    @Query("SELECT b FROM BadWordsPolicyEntity b WHERE b.endDate is null")
+    Optional<BadWordsPolicyEntity> findActiveBadWordsPolicy();
+
 }

--- a/src/main/java/yjh/devtoon/policy/presentation/PoilcyController.java
+++ b/src/main/java/yjh/devtoon/policy/presentation/PoilcyController.java
@@ -10,8 +10,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.policy.application.PolicyService;
+import yjh.devtoon.policy.domain.BadWordsPolicyEntity;
 import yjh.devtoon.policy.domain.CookiePolicyEntity;
 import yjh.devtoon.policy.dto.request.PolicyCreateRequest;
+import yjh.devtoon.policy.dto.response.RetrieveBadWordsPolicyResponse;
 import yjh.devtoon.policy.dto.response.RetrieveCookiePolicyResponse;
 
 @Slf4j
@@ -40,6 +42,17 @@ public class PoilcyController {
     public ResponseEntity<ApiResponse> retrieveCookiePolicy() {
         CookiePolicyEntity cookiePolicy = policyService.retrieveCookiePolicy();
         RetrieveCookiePolicyResponse response = RetrieveCookiePolicyResponse.from(cookiePolicy);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 비속어 정책 조회
+     */
+    @GetMapping("/bad-words-policy")
+    public ResponseEntity<ApiResponse> retrieveBadWordsPolicy() {
+        BadWordsPolicyEntity badWordsPolicy = policyService.retrieveBadWordsPolicyPolicy();
+        RetrieveBadWordsPolicyResponse response =
+                RetrieveBadWordsPolicyResponse.from(badWordsPolicy);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -3,7 +3,7 @@ INSERT INTO `bad_words_policy` (`warning_threshold`, `start_date`, `end_date`, `
 SELECT
     3,  -- 경고 임계값: 누적 3회 경고시 조치
     '2024-05-01 00:00:00',  -- 정책 시작 날짜
-    '2024-12-31 23:59:59',  -- 정책 종료 날짜
+    null,  -- 정책 종료 날짜
     CURRENT_TIMESTAMP,  -- 생성 시간
     CURRENT_TIMESTAMP  -- 업데이트 시간
 WHERE NOT EXISTS (


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 비속어 정책 조회 API구현

## 💡️ 이슈
- 해당 정책은 초기 정책으로 data.sql에 존재합니다.
  - 비속어 정책은 하나씩 존재하므로 정책 종료 날짜를 null로 변경했습니다.
- 정책 종료 날짜가 null인 비속어 정책을 조회합니다.

## 📢 논의하고 싶은 내용
- x