### PR TITLE
feat: 종료된 모든 프로모션 조회 API구현

### DIFF
--- a/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
+++ b/src/main/java/yjh/devtoon/promotion/application/PromotionService.java
@@ -134,4 +134,12 @@ public class PromotionService {
         return promotionAttributes;
     }
 
+    /**
+     * 종료된 모든 프로모션 조회
+     */
+    @Transactional(readOnly = true)
+    public List<PromotionEntity> retrieveAllEndedPromotions() {
+        return promotionRepository.findEndedPromotions();
+    }
+
 }

--- a/src/main/java/yjh/devtoon/promotion/dto/response/RetrieveEndedPromotionsResponse.java
+++ b/src/main/java/yjh/devtoon/promotion/dto/response/RetrieveEndedPromotionsResponse.java
@@ -1,0 +1,42 @@
+package yjh.devtoon.promotion.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import yjh.devtoon.promotion.domain.DiscountType;
+import yjh.devtoon.promotion.domain.PromotionEntity;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class RetrieveEndedPromotionsResponse {
+
+    private Long promotionId;
+    private String description;
+    private DiscountType discountType;
+    private BigDecimal discountRate;
+    private Integer discountQuantity;
+    private Boolean isDiscountDuplicatable;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    protected LocalDateTime deletedAt;
+
+    public static RetrieveEndedPromotionsResponse from(
+            final PromotionEntity promotionEntity
+    ) {
+        return new RetrieveEndedPromotionsResponse(
+                promotionEntity.getId(),
+                promotionEntity.getDescription(),
+                promotionEntity.getDiscountType(),
+                promotionEntity.getDiscountRate(),
+                promotionEntity.getDiscountQuantity(),
+                promotionEntity.getIsDiscountDuplicatable(),
+                promotionEntity.getStartDate(),
+                promotionEntity.getEndDate(),
+                promotionEntity.getDeletedAt()
+        );
+    }
+
+}

--- a/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionRepository.java
+++ b/src/main/java/yjh/devtoon/promotion/infrastructure/PromotionRepository.java
@@ -29,4 +29,10 @@ public interface PromotionRepository extends JpaRepository<PromotionEntity, Long
     @Query("SELECT p FROM PromotionEntity p WHERE p.startDate <= :now AND p.endDate >= :now")
     Page<PromotionEntity> activePromotions(@Param("now") LocalDateTime now, Pageable pageable);
 
+    /**
+     * 종료된 모든 프로모션 조회
+     */
+    @Query("SELECT p FROM PromotionEntity p WHERE p.deletedAt IS NOT NULL")
+    List<PromotionEntity> findEndedPromotions();
+
 }

--- a/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
+++ b/src/main/java/yjh/devtoon/promotion/presentation/PromotionController.java
@@ -19,6 +19,7 @@ import yjh.devtoon.promotion.dto.request.PromotionCreateRequest;
 import yjh.devtoon.promotion.dto.response.PromotionSoftDeleteResponse;
 import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionAttributesResponse;
 import yjh.devtoon.promotion.dto.response.RetrieveActivePromotionsResponse;
+import yjh.devtoon.promotion.dto.response.RetrieveEndedPromotionsResponse;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -42,7 +43,7 @@ public class PromotionController {
     }
 
     /**
-     * 프로모션 삭제
+     * 프로모션 삭제(종료)
      * : 삭제 시간을 통해 로직상에서 삭제 처리를 구분합니다.
      */
     @DeleteMapping("/{id}")
@@ -82,6 +83,18 @@ public class PromotionController {
                 activePromotionAttributes.stream()
                         .map(RetrieveActivePromotionAttributesResponse::from)
                         .collect(Collectors.toList());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * 종료된 모든 프로모션 조회
+     */
+    @GetMapping("/ended")
+    public ResponseEntity<ApiResponse> retrieveAllEndedPromotions() {
+        List<PromotionEntity> endedPromotions = promotionService.retrieveAllEndedPromotions();
+        List<RetrieveEndedPromotionsResponse> response = endedPromotions.stream()
+                .map(RetrieveEndedPromotionsResponse::from)
+                .toList();
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -29,18 +29,24 @@ WHERE NOT EXISTS (
 
 -- 프로모션 데이터 삽입
 -- 프로모션 1 (과거 프로모션)
-INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable, start_date, end_date, created_at, updated_at)
-SELECT '프로모션 1', 'COOKIE_QUANTITY_DISCOUNT', 3, TRUE, '2024-04-01 00:00:00', '2024-05-01 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable,
+                       start_date, end_date, deleted_at, created_at, updated_at)
+SELECT '프로모션 1', 'COOKIE_QUANTITY_DISCOUNT', 3, TRUE, '2024-04-01 00:00:00', '2024-05-01
+00:00:00', '2024-06-15 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT 1 FROM promotion WHERE description = '프로모션 1');
 
 -- 프로모션 2 (과거 프로모션)
-INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable, start_date, end_date, created_at, updated_at)
-SELECT '프로모션 2', 'COOKIE_QUANTITY_DISCOUNT', 2, FALSE, '2024-03-01 00:00:00', '2024-03-31 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable,
+                       start_date, end_date, deleted_at, created_at, updated_at)
+SELECT '프로모션 2', 'COOKIE_QUANTITY_DISCOUNT', 2, FALSE, '2024-03-01 00:00:00', '2024-03-31
+00:00:00', '2024-06-16 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT 1 FROM promotion WHERE description = '프로모션 2');
 
 -- 프로모션 3 (과거 프로모션)
-INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable, start_date, end_date, created_at, updated_at)
-SELECT '프로모션 3', 'COOKIE_QUANTITY_DISCOUNT', 4, TRUE, '2024-02-01 00:00:00', '2024-02-28 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+INSERT INTO promotion (description, discount_type, discount_quantity, is_discount_duplicatable,
+                       start_date, end_date, deleted_at, created_at, updated_at)
+SELECT '프로모션 3', 'COOKIE_QUANTITY_DISCOUNT', 4, TRUE, '2024-02-01 00:00:00', '2024-02-28
+00:00:00', '2024-06-17 00:00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT 1 FROM promotion WHERE description = '프로모션 3');
 
 -- 프로모션 4

--- a/src/test/java/yjh/devtoon/promotion/integration/PromotionIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/promotion/integration/PromotionIntegrationTest.java
@@ -378,6 +378,44 @@ public class PromotionIntegrationTest {
             );
         }
 
+        @DisplayName("종료된 모든 프로모션 조회")
+        @Test
+        void retrieveAllEndedPromotions_successfully() throws Exception {
+            // given
+            PromotionEntity endedPromotion1 = PromotionEntity.builder()
+                    .id(1L)
+                    .description("1월 할인 프로모션")
+                    .discountType(COOKIE_QUANTITY_DISCOUNT)
+                    .discountQuantity(3)
+                    .isDiscountDuplicatable(true)
+                    .startDate(LocalDateTime.now().minusMonths(1))
+                    .deletedAt(LocalDateTime.parse("2024-06-01T00:00:00"))
+                    .build();
+            promotionRepository.save(endedPromotion1);
+
+            PromotionEntity endedPromotion2 = PromotionEntity.builder()
+                    .id(2L)
+                    .description("2월 할인 프로모션")
+                    .discountType(CASH_DISCOUNT)
+                    .discountRate(BigDecimal.valueOf(30))
+                    .isDiscountDuplicatable(true)
+                    .startDate(LocalDateTime.now().minusMonths(2))
+                    .deletedAt(LocalDateTime.parse("2024-06-02T00:00:00"))
+                    .build();
+            promotionRepository.save(endedPromotion2);
+
+            // when, then
+            mockMvc.perform(get("/v1/promotions/ended")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.statusMessage").value("성공"))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data[0].description").value("1월 할인 프로모션"))
+                    .andExpect(jsonPath("$.data[0].deletedAt").value("2024-06-01T00:00:00"))
+                    .andExpect(jsonPath("$.data[1].description").value("2월 할인 프로모션"))
+                    .andExpect(jsonPath("$.data[1].deletedAt").value("2024-06-02T00:00:00"));
+        }
+
     }
 
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 종료된 모든 프로모션 조회 API 및 통합 테스트 

## 💡️ 이슈
- 프로모션 종료는 관리자만 가능합니다.
  - 종료 시 삭제 시간이 기록되므로, 종료된 프로모션을 조회하기 위해 삭제 시간이 NULL이 아닌 데이터를 왔습니다.
  - 기존 data.sql에 있는 과거 프로모션의 삭제 시간을 추가했습니다.
  
## 📢 논의하고 싶은 내용
- x