### PR TITLE
feat: 웹툰 이미지 등록 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ src/test/resources/application.yaml
 
 # api 테스트 요청 파일 관리
 /api_test/**
+
+# local 이미지 저장소
+/local_img_storage

--- a/src/main/java/yjh/devtoon/webtoon/domain/WebtoonEntity.java
+++ b/src/main/java/yjh/devtoon/webtoon/domain/WebtoonEntity.java
@@ -29,6 +29,9 @@ public class WebtoonEntity extends BaseEntity {
     @Column(name = "title", nullable = false)
     private String title;
 
+    @Column(name = "image_url")
+    private String imageUrl;
+
     @Column(name = "writerName", nullable = false)
     private String writerName;
 
@@ -44,12 +47,14 @@ public class WebtoonEntity extends BaseEntity {
             final Long id,
             final String title,
             final String writerName,
+            final String imageUrl,
             final Genre genre,
             final LocalDateTime deletedAt
     ) {
         this.id = id;
         this.title = title;
         this.writerName = writerName;
+        this.imageUrl = imageUrl;
         this.genre = genre;
         this.deletedAt = deletedAt;
     }
@@ -57,11 +62,13 @@ public class WebtoonEntity extends BaseEntity {
     public static WebtoonEntity create(
             final String title,
             final String writerName,
+            final String imageUrl,
             final Genre genre
     ) {
         return WebtoonEntity.builder()
                 .title(title)
                 .writerName(writerName)
+                .imageUrl(imageUrl)
                 .genre(genre)
                 .build();
     }

--- a/src/main/java/yjh/devtoon/webtoon/infrastructure/ImageRepository.java
+++ b/src/main/java/yjh/devtoon/webtoon/infrastructure/ImageRepository.java
@@ -1,0 +1,7 @@
+package yjh.devtoon.webtoon.infrastructure;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageRepository {
+    String upload(MultipartFile file);
+}

--- a/src/main/java/yjh/devtoon/webtoon/infrastructure/LocalImageRepository.java
+++ b/src/main/java/yjh/devtoon/webtoon/infrastructure/LocalImageRepository.java
@@ -1,0 +1,59 @@
+package yjh.devtoon.webtoon.infrastructure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.UUID;
+
+@Repository
+public class LocalImageRepository implements ImageRepository {
+
+    @Value("${file.local.upload.path}")
+    private String uploadPath;
+
+    @Override
+    public String upload(final MultipartFile file) {
+        final String uuid = UUID.randomUUID().toString();
+        final String originalName = file.getOriginalFilename();
+        final Path savePath = Paths.get(uploadPath, uuid + "_" + originalName);
+
+        try {
+            // 디렉토리가 존재하지 않으면 생성
+            Files.createDirectories(savePath.getParent());
+
+            // 디렉토리에 저장
+            file.transferTo(savePath);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("[Error] image upload failure");
+        } finally {
+            return savePath.getFileName().toString();
+        }
+    }
+
+    public void deleteDirectory(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/src/main/java/yjh/devtoon/webtoon/presentation/WebtoonController.java
+++ b/src/main/java/yjh/devtoon/webtoon/presentation/WebtoonController.java
@@ -4,13 +4,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import yjh.devtoon.common.response.ApiResponse;
 import yjh.devtoon.webtoon.application.WebtoonService;
 import yjh.devtoon.webtoon.domain.WebtoonEntity;
@@ -27,11 +29,12 @@ public class WebtoonController {
     /**
      * 웹툰 등록
      */
-    @PostMapping
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ApiResponse> registerWebtoon(
-            @RequestBody @Valid final WebtoonCreateRequest request
+            @RequestPart("request") @Valid final WebtoonCreateRequest request,
+            @RequestPart("image") final MultipartFile multipartFile
     ) {
-        webtoonService.createWebtoon(request);
+        webtoonService.createWebtoon(request, multipartFile);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
@@ -40,7 +43,7 @@ public class WebtoonController {
      */
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse> retrieve(
-        @PathVariable final Long id
+            @PathVariable final Long id
     ) {
         WebtoonEntity webtoon = webtoonService.retrieve(id);
         WebtoonResponse response = WebtoonResponse.from(webtoon);

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -4,27 +4,31 @@ spring:
     config:
         activate:
             on-profile: dev
-#    data:
-#        redis:
-#            host: ${DEV_REDIS_HOST}
-#            port: ${DEV_REDIS_PORT}
     datasource:
         url: jdbc:mysql://${DEV_MYSQL_URL}
         username: ${DEV_MYSQL_USER}
         password: ${DEV_MYSQL_PASSWORD}
     jpa:
+        defer-datasource-initialization: true
+        hibernate:
+            ddl-auto: create
         properties:
             hibernate:
-                show_sql: false
-                format_sql: false
+                show_sql: true
+                format_sql: true
         show-sql: true
     sql:
         init:
-            mode: never # data.sql 파일 실행
+            mode: always # data.sql 파일 실행
     cache:
         type: caffeine
 
 jwt:
     secret: ${JWT_SECRET}
     token-validity-in-seconds: ${JWT_EXPIRED_SECONDS}
+
+file:
+    local:
+        upload:
+            path: ${LOCAL_IMAGE_STORAGE_URL}
 

--- a/src/test/java/yjh/devtoon/webtoon/domain/WebtoonEntityTest.java
+++ b/src/test/java/yjh/devtoon/webtoon/domain/WebtoonEntityTest.java
@@ -13,7 +13,7 @@ class WebtoonEntityTest {
     @DisplayName("[create() 테스트] : 웬툰 엔티티 생성 테스트")
     @Test
     void createWebtoon_successfully() {
-        assertThatCode(() -> WebtoonEntity.create("title", "writer_name", Genre.HORROR))
+        assertThatCode(() -> WebtoonEntity.create("title", "writer_name", "image_url", Genre.HORROR))
                 .doesNotThrowAnyException();
     }
 
@@ -21,7 +21,7 @@ class WebtoonEntityTest {
     @Test
     void createWebtoon_successfully_and_validateField() {
         // when
-        WebtoonEntity webtoonEntity = WebtoonEntity.create("title", "writer_name", Genre.HORROR);
+        WebtoonEntity webtoonEntity = WebtoonEntity.create("title", "writer_name", "image_url", Genre.HORROR);
 
         // then
         assertAll(

--- a/src/test/java/yjh/devtoon/webtoon/integration/WebtoonIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/webtoon/integration/WebtoonIntegrationTest.java
@@ -3,11 +3,12 @@ package yjh.devtoon.webtoon.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -16,18 +17,24 @@ import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import yjh.devtoon.webtoon.domain.Genre;
 import yjh.devtoon.webtoon.domain.WebtoonEntity;
 import yjh.devtoon.webtoon.dto.request.WebtoonCreateRequest;
+import yjh.devtoon.webtoon.infrastructure.LocalImageRepository;
 import yjh.devtoon.webtoon.infrastructure.WebtoonRepository;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -48,6 +55,18 @@ public class WebtoonIntegrationTest {
     @Autowired
     private WebtoonRepository webtoonRepository;
 
+    @Autowired
+    private LocalImageRepository localImageRepository;
+
+    @Value("${file.local.upload.path}")
+    private String uploadPath;
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        Path path = Paths.get(uploadPath);
+        localImageRepository.deleteDirectory(path);
+    }
+
     @WithMockUser(username = "email@gmail.com", password = "password", authorities = {"MEMBER"})
     @Nested
     @DisplayName("웹툰 등록 테스트")
@@ -62,12 +81,26 @@ public class WebtoonIntegrationTest {
                     "카레곰",
                     "horror"
             );
-            final String requestBody = objectMapper.writeValueAsString(request);
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            MockMultipartFile imageFile = new MockMultipartFile(
+                    "image",
+                    "test-image.jpg",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "Test Image Content".getBytes()
+            );
+
+            MockMultipartFile jsonFile = new MockMultipartFile(
+                    "request",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    requestBody.getBytes()
+            );
 
             // when
-            mockMvc.perform(post("/v1/webtoons")
-                            .content(requestBody)
-                            .contentType(MediaType.APPLICATION_JSON))
+            mockMvc.perform(multipart("/v1/webtoons")
+                            .file(imageFile)
+                            .file(jsonFile))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.statusMessage").value("성공"))
                     .andExpect(jsonPath("$.data").value(NULL));
@@ -80,13 +113,31 @@ public class WebtoonIntegrationTest {
                                                                    String writerName,
                                                                    String genre) throws Exception {
             // given
-            final WebtoonCreateRequest request = new WebtoonCreateRequest(title, writerName, genre);
-            final String requestBody = objectMapper.writeValueAsString(request);
+            final WebtoonCreateRequest request = new WebtoonCreateRequest(
+                    title,
+                    writerName,
+                    genre
+            );
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            MockMultipartFile imageFile = new MockMultipartFile(
+                    "image",
+                    "test-image.jpg",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "Test Image Content".getBytes()
+            );
+
+            MockMultipartFile jsonFile = new MockMultipartFile(
+                    "request",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    requestBody.getBytes()
+            );
 
             // when
-            mockMvc.perform(post("/v1/webtoons")
-                            .content(requestBody)
-                            .contentType(MediaType.APPLICATION_JSON))
+            mockMvc.perform(multipart("/v1/webtoons")
+                            .file(imageFile)
+                            .file(jsonFile))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.statusMessage").value("실패"))
                     .andExpect(jsonPath("$.data.status").value(HttpStatus.BAD_REQUEST.value()));
@@ -99,13 +150,31 @@ public class WebtoonIntegrationTest {
                                                                     String writerName,
                                                                     String genre) throws Exception {
             // given
-            final WebtoonCreateRequest request = new WebtoonCreateRequest(title, writerName, genre);
-            final String requestBody = objectMapper.writeValueAsString(request);
+            final WebtoonCreateRequest request = new WebtoonCreateRequest(
+                    title,
+                    writerName,
+                    genre
+            );
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            MockMultipartFile imageFile = new MockMultipartFile(
+                    "image",
+                    "test-image.jpg",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "Test Image Content".getBytes()
+            );
+
+            MockMultipartFile jsonFile = new MockMultipartFile(
+                    "request",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    requestBody.getBytes()
+            );
 
             // when
-            mockMvc.perform(post("/v1/webtoons")
-                            .content(requestBody)
-                            .contentType(MediaType.APPLICATION_JSON))
+            mockMvc.perform(multipart("/v1/webtoons")
+                            .file(imageFile)
+                            .file(jsonFile))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.statusMessage").value("실패"))
                     .andExpect(jsonPath("$.data.status").value(HttpStatus.BAD_REQUEST.value()));
@@ -119,13 +188,31 @@ public class WebtoonIntegrationTest {
                                                                        String writerName,
                                                                        String genre) throws Exception {
             // given
-            final WebtoonCreateRequest request = new WebtoonCreateRequest(title, writerName, genre);
-            final String requestBody = objectMapper.writeValueAsString(request);
+            final WebtoonCreateRequest request = new WebtoonCreateRequest(
+                    title,
+                    writerName,
+                    genre
+            );
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            MockMultipartFile imageFile = new MockMultipartFile(
+                    "image",
+                    "test-image.jpg",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "Test Image Content".getBytes()
+            );
+
+            MockMultipartFile jsonFile = new MockMultipartFile(
+                    "request",
+                    "",
+                    MediaType.APPLICATION_JSON_VALUE,
+                    requestBody.getBytes()
+            );
 
             // when
-            mockMvc.perform(post("/v1/webtoons")
-                            .content(requestBody)
-                            .contentType(MediaType.APPLICATION_JSON))
+            mockMvc.perform(multipart("/v1/webtoons")
+                            .file(imageFile)
+                            .file(jsonFile))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.statusMessage").value("실패"))
                     .andExpect(jsonPath("$.data.status").value(HttpStatus.BAD_REQUEST.value()));
@@ -160,12 +247,26 @@ public class WebtoonIntegrationTest {
                                 "짜장곰",
                                 "horror"
                         );
-                        final String requestBody = objectMapper.writeValueAsString(request);
+                        String requestBody = objectMapper.writeValueAsString(request);
+
+                        MockMultipartFile imageFile = new MockMultipartFile(
+                                "image",
+                                "test-image.jpg",
+                                MediaType.IMAGE_JPEG_VALUE,
+                                "Test Image Content".getBytes()
+                        );
+
+                        MockMultipartFile jsonFile = new MockMultipartFile(
+                                "request",
+                                "",
+                                MediaType.APPLICATION_JSON_VALUE,
+                                requestBody.getBytes()
+                        );
 
                         // when
-                        mockMvc.perform(post("/v1/webtoons")
-                                        .content(requestBody)
-                                        .contentType(MediaType.APPLICATION_JSON))
+                        mockMvc.perform(multipart("/v1/webtoons")
+                                        .file(imageFile)
+                                        .file(jsonFile))
                                 .andExpect(status().isOk())
                                 .andExpect(jsonPath("$.statusMessage").value("실패"))
                                 .andExpect(jsonPath("$.data.status").value(HttpStatus.CONFLICT.value()));


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 웹툰을 게시할 때, 웹툰 등록 정보와 게시글 이미지를 함께 전송한다.

## 💡️ 이슈
- 현재는 로컬환경에 상대경로 ./local_img_storage에 저장하도록 구현하였습니다.
- .env 파일과 application-dev.yaml 파일 수정해야합니다.(노션에 추가할 예정)

## 📢 논의하고 싶은 내용
- 