### PR TITLE
Refactor/#93

### DIFF
--- a/src/main/java/yjh/devtoon/comment/application/CommentService.java
+++ b/src/main/java/yjh/devtoon/comment/application/CommentService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import yjh.devtoon.auth.util.SecurityUtil;
 import yjh.devtoon.comment.constant.ErrorMessage;
 import yjh.devtoon.comment.domain.CommentEntity;
 import yjh.devtoon.comment.dto.request.CommentCreateRequest;
@@ -13,6 +14,8 @@ import yjh.devtoon.comment.infrastructure.BadWordsDetector;
 import yjh.devtoon.comment.infrastructure.CommentRepository;
 import yjh.devtoon.common.exception.DevtoonException;
 import yjh.devtoon.common.exception.ErrorCode;
+import yjh.devtoon.member.application.MemberService;
+import yjh.devtoon.member.domain.MemberEntity;
 import yjh.devtoon.webtoon.application.WebtoonService;
 import yjh.devtoon.webtoon.domain.WebtoonEntity;
 
@@ -22,6 +25,7 @@ import yjh.devtoon.webtoon.domain.WebtoonEntity;
 public class CommentService {
 
     private final WebtoonService webtoonService;
+    private final MemberService memberService;
     private final CommentRepository commentRepository;
     private final BadWordsDetector badWordsDetector;
 
@@ -32,18 +36,21 @@ public class CommentService {
 
     @Transactional
     public void create(final CommentCreateRequest request) {
+        String memberEmail = SecurityUtil.getCurrentUsername()
+                .orElseThrow(() -> new IllegalArgumentException("[Error] not found authentication username"));
+
+        MemberEntity writer = memberService.retrieveMyInfo(memberEmail);
 
         /**
          * @Async를 활용한 비동기 동작
          */
-        badWordsDetector.validateBadWords(request);
+        badWordsDetector.validateBadWords(request, writer.getId());
 
         WebtoonEntity webtoon = webtoonService.retrieve(request.getWebtoonId());
 
         CommentEntity comment = CommentEntity.create(
                 webtoon.getId(),
-                request.getDetailId(),
-                request.getWriterId(),
+                writer.getId(),
                 request.getContent()
         );
         commentRepository.save(comment);

--- a/src/main/java/yjh/devtoon/comment/application/CommentService.java
+++ b/src/main/java/yjh/devtoon/comment/application/CommentService.java
@@ -51,6 +51,7 @@ public class CommentService {
         CommentEntity comment = CommentEntity.create(
                 webtoon.getId(),
                 writer.getId(),
+                writer.getName(),
                 request.getContent()
         );
         commentRepository.save(comment);

--- a/src/main/java/yjh/devtoon/comment/domain/CommentEntity.java
+++ b/src/main/java/yjh/devtoon/comment/domain/CommentEntity.java
@@ -28,7 +28,10 @@ public class CommentEntity extends BaseEntity {
     private Long webtoonId;
 
     @Column(name = "member_no", nullable = false)
-    private Long memberId;
+    private Long writerId;
+
+    @Column(name = "writer_name", nullable = false)
+    private String writerName;
 
     @Column(name = "content", nullable = false)
     private String content;
@@ -40,13 +43,15 @@ public class CommentEntity extends BaseEntity {
     public CommentEntity(
             final Long id,
             final Long webtoonId,
-            final Long memberId,
+            final Long writerId,
+            final String writerName,
             final String content,
             final LocalDateTime deletedAt
     ) {
         this.id = id;
         this.webtoonId = webtoonId;
-        this.memberId = memberId;
+        this.writerId = writerId;
+        this.writerName = writerName;
         this.content = content;
         this.deletedAt = deletedAt;
     }
@@ -54,11 +59,13 @@ public class CommentEntity extends BaseEntity {
     public static CommentEntity create(
             final Long webtoonId,
             final Long writerId,
+            final String writerName,
             final String content
     ) {
         return CommentEntity.builder()
                 .webtoonId(webtoonId)
-                .memberId(writerId)
+                .writerId(writerId)
+                .writerName(writerName)
                 .content(content)
                 .build();
     }
@@ -68,7 +75,8 @@ public class CommentEntity extends BaseEntity {
         return "CommentEntity{" +
                 "id=" + id +
                 ", webtoonId=" + webtoonId +
-                ", memberId=" + memberId +
+                ", writerId=" + writerId +
+                ", writerName='" + writerName + '\'' +
                 ", content='" + content + '\'' +
                 ", deletedAt=" + deletedAt +
                 '}';

--- a/src/main/java/yjh/devtoon/comment/domain/CommentEntity.java
+++ b/src/main/java/yjh/devtoon/comment/domain/CommentEntity.java
@@ -27,9 +27,6 @@ public class CommentEntity extends BaseEntity {
     @Column(name = "webtoon_no", nullable = false)
     private Long webtoonId;
 
-    @Column(name = "webtoon_detail_no", nullable = false)
-    private Long detailId;
-
     @Column(name = "member_no", nullable = false)
     private Long memberId;
 
@@ -43,14 +40,12 @@ public class CommentEntity extends BaseEntity {
     public CommentEntity(
             final Long id,
             final Long webtoonId,
-            final Long detailId,
             final Long memberId,
             final String content,
             final LocalDateTime deletedAt
     ) {
         this.id = id;
         this.webtoonId = webtoonId;
-        this.detailId = detailId;
         this.memberId = memberId;
         this.content = content;
         this.deletedAt = deletedAt;
@@ -58,13 +53,11 @@ public class CommentEntity extends BaseEntity {
 
     public static CommentEntity create(
             final Long webtoonId,
-            final Long detailId,
             final Long writerId,
             final String content
     ) {
         return CommentEntity.builder()
                 .webtoonId(webtoonId)
-                .detailId(detailId)
                 .memberId(writerId)
                 .content(content)
                 .build();
@@ -75,7 +68,6 @@ public class CommentEntity extends BaseEntity {
         return "CommentEntity{" +
                 "id=" + id +
                 ", webtoonId=" + webtoonId +
-                ", detailId=" + detailId +
                 ", memberId=" + memberId +
                 ", content='" + content + '\'' +
                 ", deletedAt=" + deletedAt +

--- a/src/main/java/yjh/devtoon/comment/dto/reponse/CommentResponse.java
+++ b/src/main/java/yjh/devtoon/comment/dto/reponse/CommentResponse.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 public class CommentResponse {
 
     private Long webtoonNo;
-    private Long webtoonDetailNo;
     private Long writerId;
     private String content;
     private LocalDateTime createAt;
@@ -21,7 +20,6 @@ public class CommentResponse {
     public static CommentResponse from(final CommentEntity comment) {
         CommentResponse commentResponse = new CommentResponse();
         commentResponse.webtoonNo = comment.getWebtoonId();
-        commentResponse.webtoonDetailNo = comment.getDetailId();
         commentResponse.writerId = comment.getMemberId();
         commentResponse.content = comment.getContent();
         commentResponse.createAt = comment.getCreatedAt();

--- a/src/main/java/yjh/devtoon/comment/dto/reponse/CommentResponse.java
+++ b/src/main/java/yjh/devtoon/comment/dto/reponse/CommentResponse.java
@@ -12,7 +12,8 @@ import java.time.LocalDateTime;
 public class CommentResponse {
 
     private Long webtoonNo;
-    private Long writerId;
+    private Long writerNo;
+    private String writerName;
     private String content;
     private LocalDateTime createAt;
     private LocalDateTime updatedAt;
@@ -20,7 +21,8 @@ public class CommentResponse {
     public static CommentResponse from(final CommentEntity comment) {
         CommentResponse commentResponse = new CommentResponse();
         commentResponse.webtoonNo = comment.getWebtoonId();
-        commentResponse.writerId = comment.getMemberId();
+        commentResponse.writerNo = comment.getWriterId();
+        commentResponse.writerName = comment.getWriterName();
         commentResponse.content = comment.getContent();
         commentResponse.createAt = comment.getCreatedAt();
         commentResponse.updatedAt = comment.getUpdatedAt();

--- a/src/main/java/yjh/devtoon/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/yjh/devtoon/comment/dto/request/CommentCreateRequest.java
@@ -11,10 +11,6 @@ public class CommentCreateRequest {
 
     private final Long webtoonId;
 
-    private final Long detailId;
-
-    private final Long writerId;
-
     @NotBlank(message = "content를 확인해주세요. 빈값 혹은 null 일 수 없습니다.")
     @Size(min = 1, max = 100)
     private final String content;

--- a/src/main/java/yjh/devtoon/comment/infrastructure/BadWordsDetector.java
+++ b/src/main/java/yjh/devtoon/comment/infrastructure/BadWordsDetector.java
@@ -20,11 +20,14 @@ public class BadWordsDetector {
     private final BadWordsWarningCountService badWordsWarningCountService;
 
     @Async("EventThreadPool")
-    public void validateBadWords(final CommentCreateRequest request) {
+    public void validateBadWords(
+            final CommentCreateRequest request,
+            final Long writerId
+    ) {
         int badWordsCount = detectUsingExternalApi(request.getContent());
 
         if (badWordsCount > 0) {
-            badWordsWarningCountService.increase(request.getWriterId());
+            badWordsWarningCountService.increase(writerId);
         }
     }
 

--- a/src/test/java/yjh/devtoon/comment/domain/CommentEntityTest.java
+++ b/src/test/java/yjh/devtoon/comment/domain/CommentEntityTest.java
@@ -14,7 +14,6 @@ class CommentEntityTest {
         assertThatCode(() -> CommentEntity.create(
                         1L,
                         1L,
-                        1L,
                         "작화가 너무 좋아요!"
                 )
         ).doesNotThrowAnyException();

--- a/src/test/java/yjh/devtoon/comment/domain/CommentEntityTest.java
+++ b/src/test/java/yjh/devtoon/comment/domain/CommentEntityTest.java
@@ -14,6 +14,7 @@ class CommentEntityTest {
         assertThatCode(() -> CommentEntity.create(
                         1L,
                         1L,
+                        "작성자 이름",
                         "작화가 너무 좋아요!"
                 )
         ).doesNotThrowAnyException();

--- a/src/test/java/yjh/devtoon/comment/integration/CommentIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/comment/integration/CommentIntegrationTest.java
@@ -56,8 +56,8 @@ public class CommentIntegrationTest {
     @DisplayName("댓글 등록 테스트")
     class CommentRegisterTests {
 
-        private static final String VALID_FILED_TITLE = "홍길동";
-        private static final String VALID_FILED_EMAIL = "email@gmail.ocm";
+        private static final String VALID_FILED_NAME = "홍길동";
+        private static final String VALID_FILED_EMAIL = "email@gmail.com";
         private static final String VALID_FILED_PASSWORD = "password";
 
         @DisplayName("댓글 등록 성공")
@@ -71,21 +71,17 @@ public class CommentIntegrationTest {
                     .genre(Genre.HORROR)
                     .build()
             );
-            // 웹툰 구독자 저장
-            MemberEntity savedMember =
-                    memberRepository.save(MemberEntity.builder()
-                            .name(VALID_FILED_TITLE)
-                            .email(VALID_FILED_EMAIL)
-                            .password(VALID_FILED_PASSWORD)
-                            .membershipStatus(MembershipStatus.GENERAL)
-                            .build()
-                    );
-            long detailId = 1L;
+            // 댓글 작성자 저장
+            memberRepository.save(MemberEntity.builder()
+                    .name(VALID_FILED_NAME)
+                    .email(VALID_FILED_EMAIL)
+                    .password(VALID_FILED_PASSWORD)
+                    .membershipStatus(MembershipStatus.GENERAL)
+                    .build()
+            );
 
             final CommentCreateRequest request = new CommentCreateRequest(
                     savedWebtoon.getId(),
-                    detailId,
-                    savedMember.getId(),
                     "정말 레전드 작화 네요!"
             );
             final String requestBody = objectMapper.writeValueAsString(request);
@@ -110,21 +106,17 @@ public class CommentIntegrationTest {
                     .genre(Genre.HORROR)
                     .build()
             );
-            // 웹툰 구독자 저장
-            MemberEntity savedMember =
-                    memberRepository.save(MemberEntity.builder()
-                            .name(VALID_FILED_TITLE)
-                            .email(VALID_FILED_EMAIL)
-                            .password(VALID_FILED_PASSWORD)
-                            .membershipStatus(MembershipStatus.GENERAL)
-                            .build()
-                    );
-            long detailId = 1L;
+            // 댓글 작성자 저장
+            memberRepository.save(MemberEntity.builder()
+                    .name(VALID_FILED_NAME)
+                    .email(VALID_FILED_EMAIL)
+                    .password(VALID_FILED_PASSWORD)
+                    .membershipStatus(MembershipStatus.GENERAL)
+                    .build()
+            );
 
             final CommentCreateRequest request = new CommentCreateRequest(
                     savedWebtoon.getId(),
-                    detailId,
-                    savedMember.getId(),
                     null
             );
             final String requestBody = objectMapper.writeValueAsString(request);
@@ -142,7 +134,6 @@ public class CommentIntegrationTest {
         @Test
         void givenEmptyField_whenRegisterComment_thenThrowException() throws Exception {
             // given
-            // given
             // 웹툰 저장
             WebtoonEntity savedWebtoon = webtoonRepository.save(WebtoonEntity.builder()
                     .title("쿠베라")
@@ -150,21 +141,17 @@ public class CommentIntegrationTest {
                     .genre(Genre.HORROR)
                     .build()
             );
-            // 웹툰 구독자 저장
-            MemberEntity savedMember =
-                    memberRepository.save(MemberEntity.builder()
-                            .name(VALID_FILED_TITLE)
-                            .email(VALID_FILED_EMAIL)
-                            .password(VALID_FILED_PASSWORD)
-                            .membershipStatus(MembershipStatus.GENERAL)
-                            .build()
-                    );
-            long detailId = 1L;
+            // 댓글 작성자 저장
+            memberRepository.save(MemberEntity.builder()
+                    .name(VALID_FILED_NAME)
+                    .email(VALID_FILED_EMAIL)
+                    .password(VALID_FILED_PASSWORD)
+                    .membershipStatus(MembershipStatus.GENERAL)
+                    .build()
+            );
 
             final CommentCreateRequest request = new CommentCreateRequest(
                     savedWebtoon.getId(),
-                    detailId,
-                    savedMember.getId(),
                     ""
             );
             final String requestBody = objectMapper.writeValueAsString(request);
@@ -189,21 +176,17 @@ public class CommentIntegrationTest {
                     .genre(Genre.HORROR)
                     .build()
             );
-            // 웹툰 구독자 저장
-            MemberEntity savedMember =
-                    memberRepository.save(MemberEntity.builder()
-                            .name(VALID_FILED_TITLE)
-                            .email(VALID_FILED_EMAIL)
-                            .password(VALID_FILED_PASSWORD)
-                            .membershipStatus(MembershipStatus.GENERAL)
-                            .build()
-                    );
-            long detailId = 1L;
+            // 댓글 작성자 저장
+            memberRepository.save(MemberEntity.builder()
+                    .name(VALID_FILED_NAME)
+                    .email(VALID_FILED_EMAIL)
+                    .password(VALID_FILED_PASSWORD)
+                    .membershipStatus(MembershipStatus.GENERAL)
+                    .build()
+            );
 
             final CommentCreateRequest request = new CommentCreateRequest(
                     savedWebtoon.getId(),
-                    detailId,
-                    savedMember.getId(),
                     "문" .repeat(101)
             );
             final String requestBody = objectMapper.writeValueAsString(request);
@@ -223,21 +206,17 @@ public class CommentIntegrationTest {
             // given
             long NotExistWebtoonId = 99999999999L;
 
-            // 웹툰 구독자 저장
-            MemberEntity savedMember =
-                    memberRepository.save(MemberEntity.builder()
-                            .name(VALID_FILED_TITLE)
-                            .email(VALID_FILED_EMAIL)
-                            .password(VALID_FILED_PASSWORD)
-                            .membershipStatus(MembershipStatus.GENERAL)
-                            .build()
-                    );
-            long detailId = 1L;
+            // 댓글 작성자 저장
+            memberRepository.save(MemberEntity.builder()
+                    .name(VALID_FILED_NAME)
+                    .email(VALID_FILED_EMAIL)
+                    .password(VALID_FILED_PASSWORD)
+                    .membershipStatus(MembershipStatus.GENERAL)
+                    .build()
+            );
 
             final CommentCreateRequest request = new CommentCreateRequest(
                     NotExistWebtoonId,
-                    detailId,
-                    savedMember.getId(),
                     "정말 레전드 작화 네요!"
             );
             final String requestBody = objectMapper.writeValueAsString(request);
@@ -264,7 +243,6 @@ public class CommentIntegrationTest {
             // given
             CommentEntity comment = CommentEntity.builder()
                     .webtoonId(2L)
-                    .detailId(2L)
                     .memberId(2L)
                     .content("재밌어요!")
                     .build();
@@ -276,7 +254,6 @@ public class CommentIntegrationTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.statusMessage").value("성공"))
                     .andExpect(jsonPath("$.data.webtoonNo").value(saved.getWebtoonId()))
-                    .andExpect(jsonPath("$.data.webtoonDetailNo").value(saved.getDetailId()))
                     .andExpect(jsonPath("$.data.writerId").value(saved.getMemberId()))
                     .andExpect(jsonPath("$.data.content").value(saved.getContent()));
         }
@@ -302,7 +279,6 @@ public class CommentIntegrationTest {
             long webtoonId = 2L;
             CommentEntity comment1 = CommentEntity.builder()
                     .webtoonId(webtoonId)
-                    .detailId(2L)
                     .memberId(2L)
                     .content("재밌어요!")
                     .build();
@@ -310,7 +286,6 @@ public class CommentIntegrationTest {
 
             CommentEntity comment2 = CommentEntity.builder()
                     .webtoonId(webtoonId)
-                    .detailId(2L)
                     .memberId(2L)
                     .content("최고에요!")
                     .build();

--- a/src/test/java/yjh/devtoon/comment/integration/CommentIntegrationTest.java
+++ b/src/test/java/yjh/devtoon/comment/integration/CommentIntegrationTest.java
@@ -243,7 +243,8 @@ public class CommentIntegrationTest {
             // given
             CommentEntity comment = CommentEntity.builder()
                     .webtoonId(2L)
-                    .memberId(2L)
+                    .writerId(2L)
+                    .writerName("작성자 이름")
                     .content("재밌어요!")
                     .build();
             CommentEntity saved = commentRepository.save(comment);
@@ -254,7 +255,8 @@ public class CommentIntegrationTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.statusMessage").value("성공"))
                     .andExpect(jsonPath("$.data.webtoonNo").value(saved.getWebtoonId()))
-                    .andExpect(jsonPath("$.data.writerId").value(saved.getMemberId()))
+                    .andExpect(jsonPath("$.data.writerNo").value(saved.getWriterId()))
+                    .andExpect(jsonPath("$.data.writerName").value(saved.getWriterName()))
                     .andExpect(jsonPath("$.data.content").value(saved.getContent()));
         }
 
@@ -279,14 +281,16 @@ public class CommentIntegrationTest {
             long webtoonId = 2L;
             CommentEntity comment1 = CommentEntity.builder()
                     .webtoonId(webtoonId)
-                    .memberId(2L)
+                    .writerId(2L)
+                    .writerName("작성자1")
                     .content("재밌어요!")
                     .build();
             commentRepository.save(comment1);
 
             CommentEntity comment2 = CommentEntity.builder()
                     .webtoonId(webtoonId)
-                    .memberId(2L)
+                    .writerId(2L)
+                    .writerName("작성자2")
                     .content("최고에요!")
                     .build();
             commentRepository.save(comment2);


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] 댓글 응답 형식 변경
- [x] 댓글 생성 요청 형식 변경

## 💡️ 이슈

## 📢 논의하고 싶은 내용
- 프론트 요구사항에 대해 댓글 응답에 작성자 id뿐만 아니라 작성자 이름도 반환하도록 합니다.
- 댓글 작성 요청할 때 작성자 이름을 함께 전송하는 것이 아니라, 작성자 정보는 security의 Authentication을 통해 제공받도록 변경합니다.
