### PR TITLE
chore: 시큐리티 설정에서 인증이 필요 없는 URL에 Swagger 추가

### DIFF
--- a/src/main/java/yjh/devtoon/common/config/SecurityConfig.java
+++ b/src/main/java/yjh/devtoon/common/config/SecurityConfig.java
@@ -48,6 +48,8 @@ public class SecurityConfig {
                 )
 
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/v1/auth/authenticate").permitAll()
                         .requestMatchers(HttpMethod.POST, "/v1/members").permitAll()
                         .requestMatchers(HttpMethod.GET, "/v1/bad-words-warning-count").permitAll()


### PR DESCRIPTION
## ✨ 구현한 기능
- [x] SecurityConfig에 인증이 필요 없는 URL에 Swagger 추가
  - .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
  - .requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll()

## 💡️ 이슈
- x

## 📢 논의하고 싶은 내용
- x